### PR TITLE
Improve invoice list UX and add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Biglins
 
+[![tests](https://github.com/simonecosci/biglins/actions/workflows/tests.yml/badge.svg)](https://github.com/simonecosci/biglins/actions/workflows/tests.yml)
+[![docker-publish](https://github.com/simonecosci/biglins/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/simonecosci/biglins/actions/workflows/docker-publish.yml)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](composer.json)
+
 Applicazione di fatturazione per liberi professionisti: anagrafica clienti, emissione fatture con righe/IVA, numerazione progressiva automatica, anteprima e generazione PDF, duplicazione fattura.
 
 ## Stack

--- a/resources/js/pages/companies/Edit.vue
+++ b/resources/js/pages/companies/Edit.vue
@@ -80,9 +80,9 @@ function onLogoChange(event: Event): void {
  * method instead: the wire request is a POST with `_method=put`.
  */
 function submit(): void {
-    form
-        .transform((data) => ({ ...data, _method: 'put' }))
-        .post(CompanyController.update(props.company.id).url);
+    form.transform((data) => ({ ...data, _method: 'put' })).post(
+        CompanyController.update(props.company.id).url,
+    );
 }
 
 function onDelete(): void {

--- a/resources/js/pages/invoices/Create.vue
+++ b/resources/js/pages/invoices/Create.vue
@@ -202,6 +202,15 @@ function submit(): void {
                 <InputError :message="form.errors.rows" />
 
                 <div
+                    class="grid grid-cols-[1fr_8rem_6rem_2.5rem] gap-2 text-sm text-muted-foreground"
+                >
+                    <span>Description</span>
+                    <span>Price</span>
+                    <span>VAT (%)</span>
+                    <span></span>
+                </div>
+
+                <div
                     v-for="(row, i) in form.rows"
                     :key="i"
                     class="grid grid-cols-[1fr_8rem_6rem_2.5rem] items-start gap-2"

--- a/resources/js/pages/invoices/Edit.vue
+++ b/resources/js/pages/invoices/Edit.vue
@@ -245,6 +245,15 @@ function onDelete(): void {
                 <InputError :message="form.errors.rows" />
 
                 <div
+                    class="grid grid-cols-[1fr_8rem_6rem_2.5rem] gap-2 text-sm text-muted-foreground"
+                >
+                    <span>Description</span>
+                    <span>Price</span>
+                    <span>VAT (%)</span>
+                    <span></span>
+                </div>
+
+                <div
                     v-for="(row, i) in form.rows"
                     :key="row.id ?? `new-${i}`"
                     class="grid grid-cols-[1fr_8rem_6rem_2.5rem] items-start gap-2"

--- a/resources/js/pages/invoices/Index.vue
+++ b/resources/js/pages/invoices/Index.vue
@@ -51,6 +51,7 @@ function formatTotal(total: string | number): string {
 
 function formatDate(date: string): string {
     const [year, month, day] = date.split('-');
+
     return `${day}/${month}/${year}`;
 }
 

--- a/resources/js/pages/invoices/Index.vue
+++ b/resources/js/pages/invoices/Index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Head, Link, router } from '@inertiajs/vue3';
-import { Plus } from '@lucide/vue';
+import { Copy, Eye, FileText, Pencil, Plus } from '@lucide/vue';
 import { ref } from 'vue';
 import InvoiceController from '@/actions/App/Http/Controllers/InvoiceController';
 import Heading from '@/components/Heading.vue';
@@ -47,6 +47,11 @@ function onSearch(): void {
 
 function formatTotal(total: string | number): string {
     return Number(total).toFixed(2);
+}
+
+function formatDate(date: string): string {
+    const [year, month, day] = date.split('-');
+    return `${day}/${month}/${year}`;
 }
 
 defineOptions({
@@ -98,7 +103,9 @@ defineOptions({
                         class="border-t"
                     >
                         <td class="px-4 py-2">{{ invoice.number }}</td>
-                        <td class="px-4 py-2">{{ invoice.invoice_date }}</td>
+                        <td class="px-4 py-2">
+                            {{ formatDate(invoice.invoice_date) }}
+                        </td>
                         <td class="px-4 py-2">
                             {{ invoice.customer?.name ?? '—' }}
                         </td>
@@ -114,37 +121,60 @@ defineOptions({
                         <td class="px-4 py-2">
                             {{ formatTotal(invoice.total) }}
                         </td>
-                        <td class="space-x-3 px-4 py-2 text-right">
-                            <a
-                                :href="
-                                    InvoiceController.preview(invoice.id).url
-                                "
-                                target="_blank"
-                                rel="noopener"
-                                class="text-primary underline-offset-4 hover:underline"
+                        <td class="space-x-1 px-4 py-2 text-right">
+                            <Button
+                                as-child
+                                variant="ghost"
+                                size="icon-sm"
+                                title="Preview"
                             >
-                                Preview
-                            </a>
-                            <a
-                                :href="InvoiceController.pdf(invoice.id).url"
-                                class="text-primary underline-offset-4 hover:underline"
+                                <a
+                                    :href="
+                                        InvoiceController.preview(invoice.id)
+                                            .url
+                                    "
+                                    target="_blank"
+                                    rel="noopener"
+                                >
+                                    <Eye />
+                                </a>
+                            </Button>
+                            <Button
+                                as-child
+                                variant="ghost"
+                                size="icon-sm"
+                                title="PDF"
                             >
-                                PDF
-                            </a>
-                            <Link
-                                :href="edit(invoice.id)"
-                                class="text-primary underline-offset-4 hover:underline"
+                                <a :href="InvoiceController.pdf(invoice.id).url">
+                                    <FileText />
+                                </a>
+                            </Button>
+                            <Button
+                                as-child
+                                variant="ghost"
+                                size="icon-sm"
+                                title="Edit"
                             >
-                                Edit
-                            </Link>
-                            <Link
-                                :href="
-                                    create({ query: { duplicate: invoice.id } })
-                                "
-                                class="text-primary underline-offset-4 hover:underline"
+                                <Link :href="edit(invoice.id)">
+                                    <Pencil />
+                                </Link>
+                            </Button>
+                            <Button
+                                as-child
+                                variant="ghost"
+                                size="icon-sm"
+                                title="Duplica"
                             >
-                                Duplica
-                            </Link>
+                                <Link
+                                    :href="
+                                        create({
+                                            query: { duplicate: invoice.id },
+                                        })
+                                    "
+                                >
+                                    <Copy />
+                                </Link>
+                            </Button>
                         </td>
                     </tr>
                     <tr v-if="invoices.data.length === 0">

--- a/resources/js/pages/invoices/Index.vue
+++ b/resources/js/pages/invoices/Index.vue
@@ -146,7 +146,11 @@ defineOptions({
                                 size="icon-sm"
                                 title="PDF"
                             >
-                                <a :href="InvoiceController.pdf(invoice.id).url">
+                                <a
+                                    :href="
+                                        InvoiceController.pdf(invoice.id).url
+                                    "
+                                >
                                     <FileText />
                                 </a>
                             </Button>

--- a/resources/views/invoices/template.blade.php
+++ b/resources/views/invoices/template.blade.php
@@ -73,11 +73,6 @@
                 <h1>{{ __('invoice.title') }}</h1>
                 <div>{{ __('invoice.number') }}: {{ $invoice->number }}</div>
                 <div>{{ __('invoice.date') }}: {{ $invoice->invoice_date->format('d/m/Y') }}</div>
-                <div>
-                    <span class="badge {{ $invoice->paid ? 'badge-paid' : 'badge-unpaid' }}">
-                        {{ $invoice->paid ? __('invoice.paid') : __('invoice.unpaid') }}
-                    </span>
-                </div>
             </td>
         </tr>
     </table>

--- a/tests/Feature/CountryTest.php
+++ b/tests/Feature/CountryTest.php
@@ -13,17 +13,19 @@ test('country name must be unique at the database level', function () {
     Country::factory()->create(['name' => 'Italia']);
 
     expect(fn () => Country::factory()->create(['name' => 'Italia']))
-        ->toThrow(\Illuminate\Database\QueryException::class);
+        ->toThrow(QueryException::class);
 });
 
 test('seeding the countries table populates the standard country list', function () {
-    $this->seed(\Database\Seeders\CountrySeeder::class);
+    $this->seed(CountrySeeder::class);
 
     expect(Country::query()->count())->toBe(195);
     expect(Country::query()->where('name', 'Italia')->exists())->toBeTrue();
 });
 
 use App\Models\User;
+use Database\Seeders\CountrySeeder;
+use Illuminate\Database\QueryException;
 
 test('guests are redirected to the login page when visiting countries', function () {
     $this->get(route('countries.index'))->assertRedirect(route('login'));

--- a/tests/Feature/CountryTest.php
+++ b/tests/Feature/CountryTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Models\Country;
+use App\Models\User;
+use Database\Seeders\CountrySeeder;
+use Illuminate\Database\QueryException;
 
 test('country factory creates a country with a uuid primary key', function () {
     $country = Country::factory()->create();
@@ -22,10 +25,6 @@ test('seeding the countries table populates the standard country list', function
     expect(Country::query()->count())->toBe(195);
     expect(Country::query()->where('name', 'Italia')->exists())->toBeTrue();
 });
-
-use App\Models\User;
-use Database\Seeders\CountrySeeder;
-use Illuminate\Database\QueryException;
 
 test('guests are redirected to the login page when visiting countries', function () {
     $this->get(route('countries.index'))->assertRedirect(route('login'));


### PR DESCRIPTION
## Summary
- Add status badges (tests, docker-publish, license) to the README
- Add column headers (Description, Price, VAT) above the invoice row inputs on Create/Edit
- Replace text action links (Preview/PDF/Edit/Duplica) with icon buttons in the invoice list
- Format the invoice date as d/m/Y in the invoice list
- Remove the paid/unpaid badge from the generated invoice PDF template

## Test plan
- [ ] Run `php artisan test --compact`
- [ ] Visually check the invoice list and Create/Edit pages in the browser
- [ ] Generate an invoice PDF and confirm the paid/unpaid badge is gone as intended