### PR TITLE
fix: flaky InvoiceTemplateTest with apostrophe in fake company name

### DIFF
--- a/tests/Feature/InvoiceTemplateTest.php
+++ b/tests/Feature/InvoiceTemplateTest.php
@@ -26,8 +26,8 @@ test('template renders company data, customer data and rows', function () {
 
     expect($html)->toContain('Invoice');
     expect($html)->toContain($invoice->number);
-    expect($html)->toContain($invoice->company->name);
-    expect($html)->toContain($invoice->customer->name);
+    expect($html)->toContain(e($invoice->company->name));
+    expect($html)->toContain(e($invoice->customer->name));
     expect($html)->toContain('Consulting work');
 });
 


### PR DESCRIPTION
## Summary
Fixes a flaky test in `InvoiceTemplateTest` that failed on the previous merge (`main` CI run) because Faker generated a customer name with an apostrophe (`O'Hara-Morar`). Blade's `{{ }}` HTML-escapes apostrophes to `&#039;`, so comparing against the raw name only failed intermittently depending on the random seed.

## Why
Unrelated to the previous docs-only PR — this surfaced on the `main` merge run right after, caused by random test data, not by that change.

## Fix
Compare against `e($name)` (the same escaping Blade applies) instead of the raw name.

## Test plan
- [x] Ran the affected test 5x locally to confirm it passes regardless of Faker's random name output
- [x] `vendor/bin/pint --test` passes