### PR TITLE
feat: add product duration and auto-fill invoice row expiration date

### DIFF
--- a/app/Enums/ProductDuration.php
+++ b/app/Enums/ProductDuration.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum ProductDuration: string
+{
+    case Weekly = 'weekly';
+    case Monthly = 'monthly';
+    case Yearly = 'yearly';
+}

--- a/app/Http/Requests/StoreProductRequest.php
+++ b/app/Http/Requests/StoreProductRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\ProductDuration;
 use App\Enums\ProductType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rules\Enum;
@@ -13,6 +14,13 @@ class StoreProductRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        if ($this->input('duration') === 'none') {
+            $this->merge(['duration' => null]);
+        }
+    }
+
     /**
      * @return array<string, array<mixed>>
      */
@@ -21,6 +29,7 @@ class StoreProductRequest extends FormRequest
         return [
             'code' => ['nullable', 'string', 'max:50', 'unique:products,code'],
             'type' => ['required', new Enum(ProductType::class)],
+            'duration' => ['nullable', new Enum(ProductDuration::class)],
             'description' => ['required', 'string', 'max:255'],
             'price' => ['required', 'numeric', 'min:0'],
         ];

--- a/app/Http/Requests/UpdateProductRequest.php
+++ b/app/Http/Requests/UpdateProductRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\ProductDuration;
 use App\Enums\ProductType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -14,6 +15,13 @@ class UpdateProductRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        if ($this->input('duration') === 'none') {
+            $this->merge(['duration' => null]);
+        }
+    }
+
     /**
      * @return array<string, array<mixed>>
      */
@@ -22,6 +30,7 @@ class UpdateProductRequest extends FormRequest
         return [
             'code' => ['nullable', 'string', 'max:50', Rule::unique('products', 'code')->ignore($this->route('product'))],
             'type' => ['required', new Enum(ProductType::class)],
+            'duration' => ['nullable', new Enum(ProductDuration::class)],
             'description' => ['required', 'string', 'max:255'],
             'price' => ['required', 'numeric', 'min:0'],
         ];

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\ProductDuration;
 use App\Enums\ProductType;
 use Database\Factories\ProductFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -15,13 +16,14 @@ use Illuminate\Support\Carbon;
  * @property string $id
  * @property string|null $code
  * @property ProductType $type
+ * @property ProductDuration|null $duration
  * @property string $description
  * @property float $price
  * @property string $company_id
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
-#[Fillable(['code', 'type', 'description', 'price', 'company_id'])]
+#[Fillable(['code', 'type', 'duration', 'description', 'price', 'company_id'])]
 class Product extends Model
 {
     /** @use HasFactory<ProductFactory> */
@@ -36,6 +38,7 @@ class Product extends Model
     {
         return [
             'type' => ProductType::class,
+            'duration' => ProductDuration::class,
             'price' => 'float',
         ];
     }

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\ProductDuration;
 use App\Enums\ProductType;
 use App\Models\Company;
 use App\Models\Product;
@@ -24,9 +25,20 @@ class ProductFactory extends Factory
         return [
             'code' => fake()->unique()->bothify('PRD-####'),
             'type' => fake()->randomElement(ProductType::cases()),
+            'duration' => null,
             'description' => fake()->words(3, true),
             'price' => fake()->randomFloat(2, 1, 1000),
             'company_id' => Company::factory(),
         ];
+    }
+
+    /**
+     * Indicate that the product has a recurring duration.
+     */
+    public function withDuration(?ProductDuration $duration = null): static
+    {
+        return $this->state(fn () => [
+            'duration' => $duration ?? fake()->randomElement(ProductDuration::cases()),
+        ]);
     }
 }

--- a/database/migrations/2026_08_14_092653_add_duration_to_products_table.php
+++ b/database/migrations/2026_08_14_092653_add_duration_to_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->string('duration')->nullable()->after('type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('duration');
+        });
+    }
+};

--- a/resources/js/components/ProductPicker.vue
+++ b/resources/js/components/ProductPicker.vue
@@ -19,11 +19,14 @@ import {
 } from '@/components/ui/tooltip';
 import { index } from '@/routes/products';
 
+export type ProductDuration = 'weekly' | 'monthly' | 'yearly';
+
 export type PickedProduct = {
     id: string;
     code: string | null;
     description: string;
     price: number;
+    duration: ProductDuration | null;
 };
 
 type ProductResult = PickedProduct & {
@@ -108,6 +111,7 @@ function choose(product: ProductResult): void {
         code: product.code,
         description: product.description,
         price: product.price,
+        duration: product.duration,
     });
     open.value = false;
 }

--- a/resources/js/lang/en.ts
+++ b/resources/js/lang/en.ts
@@ -449,6 +449,12 @@ const messages = {
     },
     products: {
         type: { product: 'Product', service: 'Service' },
+        duration: {
+            none: 'No duration',
+            weekly: 'Weekly',
+            monthly: 'Monthly',
+            yearly: 'Yearly',
+        },
         index: {
             title: 'Products',
             description: 'Manage your product and service catalog',
@@ -459,6 +465,7 @@ const messages = {
                 type: 'Type',
                 description: 'Description',
                 price: 'Price',
+                duration: 'Duration',
             },
             empty: 'No products found.',
         },
@@ -469,6 +476,8 @@ const messages = {
             codePlaceholder: 'Optional code',
             type: 'Type',
             selectType: 'Select a type',
+            duration: 'Duration',
+            selectDuration: 'Select a duration',
             descriptionLabel: 'Description',
             descriptionPlaceholder: 'Description',
             price: 'Price',

--- a/resources/js/lang/es.ts
+++ b/resources/js/lang/es.ts
@@ -467,6 +467,12 @@ const messages: MessageSchema = {
     },
     products: {
         type: { product: 'Producto', service: 'Servicio' },
+        duration: {
+            none: 'Sin duración',
+            weekly: 'Semanal',
+            monthly: 'Mensual',
+            yearly: 'Anual',
+        },
         index: {
             title: 'Productos',
             description: 'Gestiona tu catálogo de productos y servicios',
@@ -477,6 +483,7 @@ const messages: MessageSchema = {
                 type: 'Tipo',
                 description: 'Descripción',
                 price: 'Precio',
+                duration: 'Duración',
             },
             empty: 'No se encontraron productos.',
         },
@@ -487,6 +494,8 @@ const messages: MessageSchema = {
             codePlaceholder: 'Código opcional',
             type: 'Tipo',
             selectType: 'Selecciona un tipo',
+            duration: 'Duración',
+            selectDuration: 'Selecciona una duración',
             descriptionLabel: 'Descripción',
             descriptionPlaceholder: 'Descripción',
             price: 'Precio',

--- a/resources/js/lang/it.ts
+++ b/resources/js/lang/it.ts
@@ -462,6 +462,12 @@ const messages: MessageSchema = {
     },
     products: {
         type: { product: 'Prodotto', service: 'Servizio' },
+        duration: {
+            none: 'Nessuna scadenza',
+            weekly: 'Settimanale',
+            monthly: 'Mensile',
+            yearly: 'Annuale',
+        },
         index: {
             title: 'Prodotti',
             description: 'Gestisci il tuo catalogo di prodotti e servizi',
@@ -472,6 +478,7 @@ const messages: MessageSchema = {
                 type: 'Tipo',
                 description: 'Descrizione',
                 price: 'Prezzo',
+                duration: 'Durata',
             },
             empty: 'Nessun prodotto trovato.',
         },
@@ -482,6 +489,8 @@ const messages: MessageSchema = {
             codePlaceholder: 'Codice opzionale',
             type: 'Tipo',
             selectType: 'Seleziona un tipo',
+            duration: 'Durata',
+            selectDuration: 'Seleziona una durata',
             descriptionLabel: 'Descrizione',
             descriptionPlaceholder: 'Descrizione',
             price: 'Prezzo',

--- a/resources/js/lib/productDuration.ts
+++ b/resources/js/lib/productDuration.ts
@@ -1,0 +1,28 @@
+import type { ProductDuration } from '@/components/ProductPicker.vue';
+
+/**
+ * Adds a product's recurring duration to a date, returning the result as a
+ * `YYYY-MM-DD` string. Used to auto-fill an invoice row's expiration date
+ * when a service product with a duration is applied to it.
+ */
+export function addDurationToDate(
+    date: string,
+    duration: ProductDuration,
+): string {
+    const [year, month, day] = date.split('-').map(Number);
+    const result = new Date(Date.UTC(year, month - 1, day));
+
+    switch (duration) {
+        case 'weekly':
+            result.setUTCDate(result.getUTCDate() + 7);
+            break;
+        case 'monthly':
+            result.setUTCMonth(result.getUTCMonth() + 1);
+            break;
+        case 'yearly':
+            result.setUTCFullYear(result.getUTCFullYear() + 1);
+            break;
+    }
+
+    return result.toISOString().slice(0, 10);
+}

--- a/resources/js/pages/invoices/Create.vue
+++ b/resources/js/pages/invoices/Create.vue
@@ -19,6 +19,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { addDurationToDate } from '@/lib/productDuration';
 import { index } from '@/routes/invoices';
 import type { BreadcrumbItem } from '@/types';
 
@@ -117,6 +118,13 @@ function applyProduct(index: number, product: PickedProduct): void {
     selectedProducts.value[index] = product;
     form.rows[index].description = product.description;
     form.rows[index].price = product.price;
+
+    if (product.duration !== null) {
+        form.rows[index].expiration_date = addDurationToDate(
+            form.invoice_date,
+            product.duration,
+        );
+    }
 }
 
 const total = computed(() =>

--- a/resources/js/pages/invoices/Edit.vue
+++ b/resources/js/pages/invoices/Edit.vue
@@ -19,6 +19,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { addDurationToDate } from '@/lib/productDuration';
 import { index } from '@/routes/invoices';
 import type { BreadcrumbItem } from '@/types';
 
@@ -144,6 +145,13 @@ function applyProduct(index: number, product: PickedProduct): void {
     selectedProducts.value[index] = product;
     form.rows[index].description = product.description;
     form.rows[index].price = product.price;
+
+    if (product.duration !== null) {
+        form.rows[index].expiration_date = addDurationToDate(
+            form.invoice_date,
+            product.duration,
+        );
+    }
 }
 
 const total = computed(() =>

--- a/resources/js/pages/products/Create.vue
+++ b/resources/js/pages/products/Create.vue
@@ -73,6 +73,34 @@ setLayoutProps({
             </div>
 
             <div class="grid gap-2">
+                <Label for="duration">{{
+                    t('products.create.duration')
+                }}</Label>
+                <Select name="duration" default-value="none">
+                    <SelectTrigger id="duration" class="w-full">
+                        <SelectValue
+                            :placeholder="t('products.create.selectDuration')"
+                        />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="none">{{
+                            t('products.duration.none')
+                        }}</SelectItem>
+                        <SelectItem value="weekly">{{
+                            t('products.duration.weekly')
+                        }}</SelectItem>
+                        <SelectItem value="monthly">{{
+                            t('products.duration.monthly')
+                        }}</SelectItem>
+                        <SelectItem value="yearly">{{
+                            t('products.duration.yearly')
+                        }}</SelectItem>
+                    </SelectContent>
+                </Select>
+                <InputError :message="errors.duration" />
+            </div>
+
+            <div class="grid gap-2">
                 <Label for="description">{{
                     t('products.create.descriptionLabel')
                 }}</Label>

--- a/resources/js/pages/products/Edit.vue
+++ b/resources/js/pages/products/Edit.vue
@@ -21,6 +21,7 @@ type Product = {
     id: string;
     code: string | null;
     type: 'product' | 'service';
+    duration: 'weekly' | 'monthly' | 'yearly' | null;
     description: string;
     price: number;
 };
@@ -91,6 +92,37 @@ function onDelete(): void {
                     </Select>
                     <InputError :message="errors.type" />
                 </div>
+            </div>
+
+            <div class="grid gap-2">
+                <Label for="duration">{{
+                    t('products.create.duration')
+                }}</Label>
+                <Select
+                    name="duration"
+                    :default-value="product.duration ?? 'none'"
+                >
+                    <SelectTrigger id="duration" class="w-full">
+                        <SelectValue
+                            :placeholder="t('products.create.selectDuration')"
+                        />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="none">{{
+                            t('products.duration.none')
+                        }}</SelectItem>
+                        <SelectItem value="weekly">{{
+                            t('products.duration.weekly')
+                        }}</SelectItem>
+                        <SelectItem value="monthly">{{
+                            t('products.duration.monthly')
+                        }}</SelectItem>
+                        <SelectItem value="yearly">{{
+                            t('products.duration.yearly')
+                        }}</SelectItem>
+                    </SelectContent>
+                </Select>
+                <InputError :message="errors.duration" />
             </div>
 
             <div class="grid gap-2">

--- a/resources/js/pages/products/Index.vue
+++ b/resources/js/pages/products/Index.vue
@@ -13,6 +13,7 @@ type Product = {
     id: string;
     code: string | null;
     type: 'product' | 'service';
+    duration: 'weekly' | 'monthly' | 'yearly' | null;
     description: string;
     price: number;
 };
@@ -40,6 +41,14 @@ const { t } = useI18n();
 const typeLabels = computed<Record<Product['type'], string>>(() => ({
     product: t('products.type.product'),
     service: t('products.type.service'),
+}));
+
+const durationLabels = computed<
+    Record<NonNullable<Product['duration']>, string>
+>(() => ({
+    weekly: t('products.duration.weekly'),
+    monthly: t('products.duration.monthly'),
+    yearly: t('products.duration.yearly'),
 }));
 
 function onSearch(): void {
@@ -97,6 +106,9 @@ setLayoutProps({
                         <th class="px-4 py-2 font-medium">
                             {{ t('products.index.columns.price') }}
                         </th>
+                        <th class="px-4 py-2 font-medium">
+                            {{ t('products.index.columns.duration') }}
+                        </th>
                         <th class="px-4 py-2"></th>
                     </tr>
                 </thead>
@@ -114,6 +126,13 @@ setLayoutProps({
                         <td class="px-4 py-2">
                             {{ product.price.toFixed(2) }}
                         </td>
+                        <td class="px-4 py-2">
+                            {{
+                                product.duration
+                                    ? durationLabels[product.duration]
+                                    : '—'
+                            }}
+                        </td>
                         <td class="px-4 py-2 text-right">
                             <Button
                                 as-child
@@ -129,7 +148,7 @@ setLayoutProps({
                     </tr>
                     <tr v-if="products.data.length === 0">
                         <td
-                            colspan="5"
+                            colspan="6"
                             class="px-4 py-6 text-center text-muted-foreground"
                         >
                             {{ t('products.index.empty') }}

--- a/tests/Feature/ProductTest.php
+++ b/tests/Feature/ProductTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\ProductDuration;
 use App\Enums\ProductType;
 use App\Models\Company;
 use App\Models\Product;
@@ -12,6 +13,13 @@ test('product factory creates a product', function () {
     expect($product->id)->toBeString();
     expect(strlen($product->id))->toBe(36);
     expect($product->type)->toBeInstanceOf(ProductType::class);
+    expect($product->duration)->toBeNull();
+});
+
+test('product factory can create a product with a duration', function () {
+    $product = Product::factory()->withDuration(ProductDuration::Monthly)->create();
+
+    expect($product->duration)->toBe(ProductDuration::Monthly);
 });
 
 test('product belongs to a company', function () {
@@ -86,6 +94,17 @@ test('products index can be searched as json for the invoice picker', function (
         ->toBe(['SKU-1', 'SKU-2']);
 });
 
+test('the product picker json response includes the duration', function () {
+    $user = User::factory()->create();
+    $company = Company::factory()->create();
+    Product::factory()->withDuration(ProductDuration::Weekly)->create(['company_id' => $company->id, 'code' => 'SKU-1', 'description' => 'Blue widget']);
+
+    $response = $this->actingAs($user)->withSession(['current_company_id' => $company->id])->getJson(route('products.index', ['search' => 'widget']));
+
+    $response->assertOk();
+    expect($response->json('data.0.duration'))->toBe(ProductDuration::Weekly->value);
+});
+
 test('the product picker json response does not include products from another company', function () {
     $user = User::factory()->create();
     $company = Company::factory()->create();
@@ -110,6 +129,52 @@ test('products index json response is paginated', function () {
     $response->assertOk();
     expect($response->json('data'))->toHaveCount(15);
     expect($response->json('last_page'))->toBe(2);
+});
+
+test('product can be created with a duration', function () {
+    $user = User::factory()->create();
+    $company = Company::factory()->create();
+
+    $response = $this->actingAs($user)->withSession(['current_company_id' => $company->id])->post(route('products.store'), [
+        'type' => ProductType::Service->value,
+        'duration' => ProductDuration::Yearly->value,
+        'description' => 'Hosting',
+        'price' => 199,
+    ]);
+
+    $response->assertSessionHasNoErrors()->assertRedirect(route('products.index'));
+    expect(Product::query()->where('description', 'Hosting')->first()->duration)->toBe(ProductDuration::Yearly);
+});
+
+test('submitting duration as none clears it to null', function () {
+    $user = User::factory()->create();
+    $company = Company::factory()->create();
+    $product = Product::factory()->withDuration(ProductDuration::Monthly)->create(['company_id' => $company->id]);
+
+    $response = $this->actingAs($user)->withSession(['current_company_id' => $company->id])->put(route('products.update', $product), [
+        'code' => $product->code,
+        'type' => $product->type->value,
+        'duration' => 'none',
+        'description' => $product->description,
+        'price' => $product->price,
+    ]);
+
+    $response->assertSessionHasNoErrors();
+    expect($product->fresh()->duration)->toBeNull();
+});
+
+test('product duration must be a valid enum value', function () {
+    $user = User::factory()->create();
+    $company = Company::factory()->create();
+
+    $response = $this->actingAs($user)->withSession(['current_company_id' => $company->id])->post(route('products.store'), [
+        'type' => ProductType::Service->value,
+        'duration' => 'invalid',
+        'description' => 'Hosting',
+        'price' => 199,
+    ]);
+
+    $response->assertSessionHasErrors('duration');
 });
 
 test('product can be created without a code', function () {


### PR DESCRIPTION
## Summary
- Add a `duration` field to products (weekly/monthly/yearly), editable on the product create/edit forms and shown in the product list.
- When a product with a duration is applied to an invoice row (via the product picker), the row's expiration date is now computed automatically from the invoice date + duration, reusing the existing subscription/scadenziario mechanism. Products without a duration are unaffected.

## Test plan
- [x] `php artisan test --compact` — 224/224 passing
- [x] `vendor/bin/pint --dirty --format agent` — clean
- [x] `vendor/bin/phpstan analyse` — 0 errors
- [x] `npm run types:check` / `npm run lint:check` / `npm run format:check` — clean
- [x] Manual check in the browser (product create/edit duration field, invoice row auto-fill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)