### PR TITLE
feat: invoice credit notes and a shared confirmation dialog

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -49,7 +49,8 @@ UUID primary key. Belongs to `customers` (`customer_id`, `restrictOnDelete` — 
 
 | Column | Notes |
 |---|---|
-| `number` | unique per company (`unique(company_id, number)`), auto-generated as `{year}-{4-digit sequence}` (`Invoice::nextNumber(string $companyId, ?string $year = null)`), resets per year and per company |
+| `number` | unique per company (`unique(company_id, number)`), auto-generated as `{year}-{4-digit sequence}` (`Invoice::nextNumber(string $companyId, ?string $year = null)`), resets per year and per company — shared sequence between invoices and credit notes |
+| `type` | string, cast to `App\Enums\InvoiceType` (`invoice` \| `credit_note`), default `invoice` — a credit note reverses a previous invoice: its row prices are stored negative (entered as positive in the form, negated on save), so `subtotal`/`vat_total`/`total` come out negative too |
 | `invoice_date` | date |
 | `paid` | boolean, default `false` |
 | `customer_id` | FK → `customers.id` |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![docker-publish](https://github.com/simonecosci/biglins/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/simonecosci/biglins/actions/workflows/docker-publish.yml)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Invoicing app for freelancers and sole proprietors: customer records, invoices with line items/VAT, automatic sequential numbering, PDF preview and generation, invoice duplication, a renewal schedule for recurring services (domains, hosting, maintenance) with renew/cancel actions from the dashboard, and a year-to-date revenue summary.
+Invoicing app for freelancers and sole proprietors: customer records, invoices with line items/VAT, credit notes to reverse a previous invoice, automatic sequential numbering, PDF preview and generation, invoice duplication, a renewal schedule for recurring services (domains, hosting, maintenance) with renew/cancel actions from the dashboard, and a year-to-date revenue summary.
 
 ## Stack
 
@@ -65,7 +65,7 @@ The app runs at `http://localhost:8080` (port configurable via `APP_PORT` in `.e
 
 - `app/Http/Controllers` — Inertia controllers (`CustomerController`, `InvoiceController`, `SubscriptionController`, `DashboardController`, `CountryController`, ...)
 - `app/Models` — `Customer`, `Invoice`, `InvoiceRow`, `Country`, `User` (UUID primary keys except `User`)
-- `app/Enums` — `SubscriptionStatus`, `ExpirationUrgency`, `ProductType`
+- `app/Enums` — `SubscriptionStatus`, `ExpirationUrgency`, `ProductType`, `InvoiceType` (`invoice` / `credit_note`)
 - `app/Actions/Fortify` — authentication actions (Fortify)
 - `resources/js/pages` — Inertia/Vue pages
 - `public/images/companies` — logos of issuing companies uploaded via the UI (**not versioned**, see `.gitignore`)

--- a/app/Enums/InvoiceType.php
+++ b/app/Enums/InvoiceType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum InvoiceType: string
+{
+    case Invoice = 'invoice';
+    case CreditNote = 'credit_note';
+}

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -95,7 +95,7 @@ class InvoiceController extends Controller
                 'company_id' => $currentCompany->id,
             ]);
 
-            $rows = collect($request->safe()->input('rows'))
+            $rows = collect($this->rowsInput($request))
                 ->map(fn (array $row): array => $this->normalizeRowPrice($row, $invoice->type));
 
             $invoice->rows()->createMany($rows);
@@ -154,7 +154,7 @@ class InvoiceController extends Controller
     /**
      * @return array<int, array<string, mixed>>
      */
-    private function rowsInput(UpdateInvoiceRequest $request): array
+    private function rowsInput(StoreInvoiceRequest|UpdateInvoiceRequest $request): array
     {
         return $request->safe()->input('rows');
     }

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\InvoiceType;
 use App\Http\Controllers\Concerns\ScopesToCurrentCompany;
 use App\Http\Requests\StoreInvoiceRequest;
 use App\Http\Requests\UpdateInvoiceRequest;
@@ -68,10 +69,11 @@ class InvoiceController extends Controller
                 ...($source->company_id === $currentCompany->id ? ['customer_id' => $source->customer_id] : []),
                 'note' => $source->note,
                 'language' => $source->language,
+                'type' => $source->type->value,
                 'rows' => $source->rows->map(fn (InvoiceRow $row): array => [
                     'description' => $row->description,
                     'quantity' => $row->quantity,
-                    'price' => $row->price,
+                    'price' => $source->isCreditNote() ? abs($row->price) : $row->price,
                     'vat_rate' => $row->vat_rate,
                     'expiration_date' => $row->expiration_date?->format('Y-m-d'),
                 ])->all(),
@@ -93,7 +95,10 @@ class InvoiceController extends Controller
                 'company_id' => $currentCompany->id,
             ]);
 
-            $invoice->rows()->createMany($request->safe()->input('rows'));
+            $rows = collect($request->safe()->input('rows'))
+                ->map(fn (array $row): array => $this->normalizeRowPrice($row, $invoice->type));
+
+            $invoice->rows()->createMany($rows);
         });
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invoice created.')]);
@@ -105,8 +110,14 @@ class InvoiceController extends Controller
     {
         $this->authorizeCurrentCompany($invoice);
 
+        $invoice->load('rows');
+
+        if ($invoice->isCreditNote()) {
+            $invoice->rows->each(fn (InvoiceRow $row) => $row->price = abs($row->price));
+        }
+
         return Inertia::render('invoices/Edit', [
-            'invoice' => $invoice->load('rows'),
+            'invoice' => $invoice,
             'customers' => Customer::query()->where('company_id', $invoice->company_id)->orderBy('name')->get(['id', 'name']),
         ]);
     }
@@ -118,7 +129,8 @@ class InvoiceController extends Controller
         DB::transaction(function () use ($request, $invoice) {
             $invoice->update($request->safe()->except('rows'));
 
-            $rows = collect($this->rowsInput($request));
+            $rows = collect($this->rowsInput($request))
+                ->map(fn (array $row): array => $this->normalizeRowPrice($row, $invoice->type));
             $keepIds = $rows->pluck('id')->filter()->all();
 
             $invoice->rows()->whereNotIn('id', $keepIds)->delete();
@@ -145,6 +157,19 @@ class InvoiceController extends Controller
     private function rowsInput(UpdateInvoiceRequest $request): array
     {
         return $request->safe()->input('rows');
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function normalizeRowPrice(array $row, InvoiceType $type): array
+    {
+        if ($type === InvoiceType::CreditNote) {
+            $row['price'] = -abs((float) $row['price']);
+        }
+
+        return $row;
     }
 
     public function destroy(Invoice $invoice): RedirectResponse

--- a/app/Http/Requests/StoreInvoiceRequest.php
+++ b/app/Http/Requests/StoreInvoiceRequest.php
@@ -23,6 +23,7 @@ class StoreInvoiceRequest extends FormRequest
                 'nullable', 'string', 'max:20',
                 Rule::unique('invoices', 'number')->where('company_id', CurrentCompany::resolve()?->id),
             ],
+            'type' => ['sometimes', 'string', Rule::in(['invoice', 'credit_note'])],
             'invoice_date' => ['required', 'date'],
             'paid' => ['boolean'],
             'customer_id' => [

--- a/app/Http/Requests/UpdateInvoiceRequest.php
+++ b/app/Http/Requests/UpdateInvoiceRequest.php
@@ -25,6 +25,7 @@ class UpdateInvoiceRequest extends FormRequest
                     ->where('company_id', CurrentCompany::resolve()?->id)
                     ->ignore($this->route('invoice')),
             ],
+            'type' => ['sometimes', 'string', Rule::in(['invoice', 'credit_note'])],
             'invoice_date' => ['required', 'date'],
             'paid' => ['boolean'],
             'customer_id' => [

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -61,7 +61,7 @@ class Invoice extends Model
                 $invoice->number = static::nextNumber($invoice->company_id);
             }
 
-            if (! $invoice->type) {
+            if (! ($invoice->getAttributes()['type'] ?? null)) {
                 $invoice->type = InvoiceType::Invoice;
             }
         });

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\InvoiceType;
 use Database\Factories\InvoiceFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -15,6 +16,7 @@ use Illuminate\Support\Carbon;
 /**
  * @property string $id
  * @property string $number
+ * @property InvoiceType $type
  * @property Carbon $invoice_date
  * @property bool $paid
  * @property string $customer_id
@@ -27,7 +29,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
-#[Fillable(['number', 'invoice_date', 'paid', 'customer_id', 'company_id', 'note', 'language'])]
+#[Fillable(['number', 'type', 'invoice_date', 'paid', 'customer_id', 'company_id', 'note', 'language'])]
 class Invoice extends Model
 {
     /** @use HasFactory<InvoiceFactory> */
@@ -46,6 +48,7 @@ class Invoice extends Model
     protected function casts(): array
     {
         return [
+            'type' => InvoiceType::class,
             'invoice_date' => 'date:Y-m-d',
             'paid' => 'boolean',
         ];
@@ -57,7 +60,16 @@ class Invoice extends Model
             if (! $invoice->number) {
                 $invoice->number = static::nextNumber($invoice->company_id);
             }
+
+            if (! $invoice->type) {
+                $invoice->type = InvoiceType::Invoice;
+            }
         });
+    }
+
+    public function isCreditNote(): bool
+    {
+        return $this->type === InvoiceType::CreditNote;
     }
 
     public static function nextNumber(string $companyId, ?string $year = null): string

--- a/database/factories/InvoiceFactory.php
+++ b/database/factories/InvoiceFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\InvoiceType;
 use App\Models\Company;
 use App\Models\Customer;
 use App\Models\Invoice;
@@ -21,6 +22,7 @@ class InvoiceFactory extends Factory
     {
         return [
             'number' => null,
+            'type' => InvoiceType::Invoice,
             'invoice_date' => fake()->dateTimeBetween('-6 months', 'now')->format('Y-m-d'),
             'paid' => fake()->boolean(),
             'company_id' => Company::factory(),
@@ -28,5 +30,12 @@ class InvoiceFactory extends Factory
             'note' => fake()->optional()->sentence(),
             'language' => fake()->randomElement(['it', 'en', 'es']),
         ];
+    }
+
+    public function creditNote(): static
+    {
+        return $this->state(fn (): array => [
+            'type' => InvoiceType::CreditNote,
+        ]);
     }
 }

--- a/database/migrations/2026_08_15_033201_add_type_to_invoices_table.php
+++ b/database/migrations/2026_08_15_033201_add_type_to_invoices_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->string('type')->default('invoice')->after('number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->dropColumn('type');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
                 "@laravel/vite-plugin-wayfinder": "^0.1.3",
+                "@playwright/test": "^1.62.1",
                 "@stylistic/eslint-plugin": "^5.10.0",
                 "@tailwindcss/vite": "^4.1.11",
                 "@types/node": "^22.13.5",
@@ -745,6 +746,22 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+            "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.62.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
@@ -5574,6 +5591,53 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+            "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.62.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+            "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@laravel/vite-plugin-wayfinder": "^0.1.3",
+        "@playwright/test": "^1.62.1",
         "@stylistic/eslint-plugin": "^5.10.0",
         "@tailwindcss/vite": "^4.1.11",
         "@types/node": "^22.13.5",

--- a/resources/js/components/ConfirmDialog.vue
+++ b/resources/js/components/ConfirmDialog.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    resolveConfirmDialog,
+    useConfirmDialogState,
+} from '@/lib/confirmDialog';
+
+const { t } = useI18n();
+const state = useConfirmDialogState();
+
+function onUpdateOpen(open: boolean): void {
+    if (!open) {
+        resolveConfirmDialog(false);
+    }
+}
+</script>
+
+<template>
+    <Dialog :open="state.open" @update:open="onUpdateOpen">
+        <DialogContent>
+            <DialogHeader>
+                <DialogTitle>{{
+                    state.title || t('common.confirm.title')
+                }}</DialogTitle>
+                <DialogDescription>{{ state.message }}</DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+                <Button variant="outline" @click="resolveConfirmDialog(false)">
+                    {{ t('common.actions.cancel') }}
+                </Button>
+                <Button
+                    variant="destructive"
+                    @click="resolveConfirmDialog(true)"
+                >
+                    {{ t('common.actions.confirm') }}
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/dashboard/SubscriptionsWidget.vue
+++ b/resources/js/components/dashboard/SubscriptionsWidget.vue
@@ -5,6 +5,7 @@ import SubscriptionController from '@/actions/App/Http/Controllers/SubscriptionC
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { confirmDialog } from '@/lib/confirmDialog';
 
 type SubscriptionStatus = 'expired' | 'expiring_soon' | 'upcoming';
 
@@ -50,14 +51,14 @@ function renewGroup(invoiceId: string): void {
     router.post(SubscriptionController.renew(invoiceId).url);
 }
 
-function cancelGroup(invoiceId: string): void {
-    if (confirm(t('dashboard.subscriptions.confirmCancelGroup'))) {
+async function cancelGroup(invoiceId: string): Promise<void> {
+    if (await confirmDialog(t('dashboard.subscriptions.confirmCancelGroup'))) {
         router.post(SubscriptionController.cancelGroup(invoiceId).url);
     }
 }
 
-function cancelRow(rowId: string): void {
-    if (confirm(t('dashboard.subscriptions.confirmCancelRow'))) {
+async function cancelRow(rowId: string): Promise<void> {
+    if (await confirmDialog(t('dashboard.subscriptions.confirmCancelRow'))) {
         router.post(SubscriptionController.cancelRow(rowId).url);
     }
 }

--- a/resources/js/lang/en.ts
+++ b/resources/js/lang/en.ts
@@ -3,10 +3,14 @@ const messages = {
         actions: {
             save: 'Save',
             cancel: 'Cancel',
+            confirm: 'Confirm',
             edit: 'Edit',
             previous: 'Previous',
             next: 'Next',
             addRow: 'Add row',
+        },
+        confirm: {
+            title: 'Are you sure?',
         },
         fields: {
             name: 'Name',
@@ -398,6 +402,7 @@ const messages = {
         },
     },
     invoices: {
+        type: { invoice: 'Invoice', credit_note: 'Credit Note' },
         index: {
             title: 'Invoices',
             description: 'Manage your invoices',
@@ -407,6 +412,7 @@ const messages = {
                 number: 'Number',
                 date: 'Date',
                 customer: 'Customer',
+                type: 'Type',
                 paid: 'Paid',
                 total: 'Total',
             },
@@ -426,6 +432,8 @@ const messages = {
             selectCustomer: 'Select a customer',
             language: 'Language',
             selectLanguage: 'Select a language',
+            type: 'Type',
+            selectType: 'Select a type',
             paid: 'Paid',
             note: 'Note',
             notePlaceholder: 'Optional note',

--- a/resources/js/lang/es.ts
+++ b/resources/js/lang/es.ts
@@ -5,10 +5,14 @@ const messages: MessageSchema = {
         actions: {
             save: 'Guardar',
             cancel: 'Cancelar',
+            confirm: 'Confirmar',
             edit: 'Editar',
             previous: 'Anterior',
             next: 'Siguiente',
             addRow: 'Añadir línea',
+        },
+        confirm: {
+            title: '¿Estás seguro?',
         },
         fields: {
             name: 'Nombre',
@@ -415,6 +419,7 @@ const messages: MessageSchema = {
         },
     },
     invoices: {
+        type: { invoice: 'Factura', credit_note: 'Nota de crédito' },
         index: {
             title: 'Facturas',
             description: 'Gestiona tus facturas',
@@ -424,6 +429,7 @@ const messages: MessageSchema = {
                 number: 'Número',
                 date: 'Fecha',
                 customer: 'Cliente',
+                type: 'Tipo',
                 paid: 'Pagada',
                 total: 'Total',
             },
@@ -443,6 +449,8 @@ const messages: MessageSchema = {
             selectCustomer: 'Selecciona un cliente',
             language: 'Idioma',
             selectLanguage: 'Selecciona un idioma',
+            type: 'Tipo',
+            selectType: 'Selecciona un tipo',
             paid: 'Pagada',
             note: 'Nota',
             notePlaceholder: 'Nota opcional',

--- a/resources/js/lang/it.ts
+++ b/resources/js/lang/it.ts
@@ -5,10 +5,14 @@ const messages: MessageSchema = {
         actions: {
             save: 'Salva',
             cancel: 'Annulla',
+            confirm: 'Conferma',
             edit: 'Modifica',
             previous: 'Precedente',
             next: 'Successivo',
             addRow: 'Aggiungi riga',
+        },
+        confirm: {
+            title: 'Sei sicuro?',
         },
         fields: {
             name: 'Nome',
@@ -410,6 +414,7 @@ const messages: MessageSchema = {
         },
     },
     invoices: {
+        type: { invoice: 'Fattura', credit_note: 'Nota di credito' },
         index: {
             title: 'Fatture',
             description: 'Gestisci le tue fatture',
@@ -419,6 +424,7 @@ const messages: MessageSchema = {
                 number: 'Numero',
                 date: 'Data',
                 customer: 'Cliente',
+                type: 'Tipo',
                 paid: 'Pagata',
                 total: 'Totale',
             },
@@ -438,6 +444,8 @@ const messages: MessageSchema = {
             selectCustomer: 'Seleziona un cliente',
             language: 'Lingua',
             selectLanguage: 'Seleziona una lingua',
+            type: 'Tipo',
+            selectType: 'Seleziona un tipo',
             paid: 'Pagata',
             note: 'Nota',
             notePlaceholder: 'Nota opzionale',

--- a/resources/js/layouts/app/AppHeaderLayout.vue
+++ b/resources/js/layouts/app/AppHeaderLayout.vue
@@ -2,6 +2,7 @@
 import AppContent from '@/components/AppContent.vue';
 import AppHeader from '@/components/AppHeader.vue';
 import AppShell from '@/components/AppShell.vue';
+import ConfirmDialog from '@/components/ConfirmDialog.vue';
 import { Toaster } from '@/components/ui/sonner';
 import type { BreadcrumbItem } from '@/types';
 
@@ -21,5 +22,6 @@ withDefaults(defineProps<Props>(), {
             <slot />
         </AppContent>
         <Toaster />
+        <ConfirmDialog />
     </AppShell>
 </template>

--- a/resources/js/layouts/app/AppSidebarLayout.vue
+++ b/resources/js/layouts/app/AppSidebarLayout.vue
@@ -3,6 +3,7 @@ import AppContent from '@/components/AppContent.vue';
 import AppShell from '@/components/AppShell.vue';
 import AppSidebar from '@/components/AppSidebar.vue';
 import AppSidebarHeader from '@/components/AppSidebarHeader.vue';
+import ConfirmDialog from '@/components/ConfirmDialog.vue';
 import { Toaster } from '@/components/ui/sonner';
 import type { BreadcrumbItem } from '@/types';
 
@@ -23,5 +24,6 @@ withDefaults(defineProps<Props>(), {
             <slot />
         </AppContent>
         <Toaster />
+        <ConfirmDialog />
     </AppShell>
 </template>

--- a/resources/js/lib/confirmDialog.ts
+++ b/resources/js/lib/confirmDialog.ts
@@ -1,0 +1,34 @@
+import { reactive } from 'vue';
+
+type ConfirmDialogState = {
+    open: boolean;
+    title: string;
+    message: string;
+    resolve: ((value: boolean) => void) | null;
+};
+
+const state = reactive<ConfirmDialogState>({
+    open: false,
+    title: '',
+    message: '',
+    resolve: null,
+});
+
+export function useConfirmDialogState(): ConfirmDialogState {
+    return state;
+}
+
+export function confirmDialog(message: string, title = ''): Promise<boolean> {
+    return new Promise((resolve) => {
+        state.title = title;
+        state.message = message;
+        state.open = true;
+        state.resolve = resolve;
+    });
+}
+
+export function resolveConfirmDialog(result: boolean): void {
+    state.open = false;
+    state.resolve?.(result);
+    state.resolve = null;
+}

--- a/resources/js/pages/companies/Edit.vue
+++ b/resources/js/pages/companies/Edit.vue
@@ -15,6 +15,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { confirmDialog } from '@/lib/confirmDialog';
 import { index } from '@/routes/companies';
 import type { BreadcrumbItem } from '@/types';
 
@@ -86,8 +87,8 @@ function submit(): void {
     );
 }
 
-function onDelete(): void {
-    if (confirm(t('companies.edit.confirmDelete'))) {
+async function onDelete(): Promise<void> {
+    if (await confirmDialog(t('companies.edit.confirmDelete'))) {
         router.delete(CompanyController.destroy(props.company.id).url);
     }
 }

--- a/resources/js/pages/countries/Edit.vue
+++ b/resources/js/pages/countries/Edit.vue
@@ -7,6 +7,7 @@ import InputError from '@/components/InputError.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { confirmDialog } from '@/lib/confirmDialog';
 import { index } from '@/routes/countries';
 import type { BreadcrumbItem } from '@/types';
 
@@ -27,8 +28,8 @@ setLayoutProps({
     ] satisfies BreadcrumbItem[],
 });
 
-function onDelete(): void {
-    if (confirm(t('countries.edit.confirmDelete'))) {
+async function onDelete(): Promise<void> {
+    if (await confirmDialog(t('countries.edit.confirmDelete'))) {
         router.delete(CountryController.destroy(props.country.id).url);
     }
 }

--- a/resources/js/pages/customers/Edit.vue
+++ b/resources/js/pages/customers/Edit.vue
@@ -14,6 +14,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { confirmDialog } from '@/lib/confirmDialog';
 import { index } from '@/routes/customers';
 import type { BreadcrumbItem } from '@/types';
 
@@ -49,8 +50,8 @@ setLayoutProps({
     ] satisfies BreadcrumbItem[],
 });
 
-function onDelete(): void {
-    if (confirm(t('customers.edit.confirmDelete'))) {
+async function onDelete(): Promise<void> {
+    if (await confirmDialog(t('customers.edit.confirmDelete'))) {
         router.delete(CustomerController.destroy(props.customer.id).url);
     }
 }

--- a/resources/js/pages/estimations/Create.vue
+++ b/resources/js/pages/estimations/Create.vue
@@ -19,6 +19,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { confirmDialog } from '@/lib/confirmDialog';
 import { index } from '@/routes/estimations';
 import type { BreadcrumbItem } from '@/types';
 
@@ -83,8 +84,8 @@ function addRow(): void {
     selectedProducts.value.push(undefined);
 }
 
-function removeRow(index: number): void {
-    if (!confirm(t('estimations.create.confirmRemoveRow'))) {
+async function removeRow(index: number): Promise<void> {
+    if (!(await confirmDialog(t('estimations.create.confirmRemoveRow')))) {
         return;
     }
 

--- a/resources/js/pages/estimations/Edit.vue
+++ b/resources/js/pages/estimations/Edit.vue
@@ -21,6 +21,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { confirmDialog } from '@/lib/confirmDialog';
 import { estimationStatusBadgeVariant } from '@/lib/estimationStatus';
 import { index } from '@/routes/estimations';
 import { edit as editInvoice } from '@/routes/invoices';
@@ -127,8 +128,8 @@ function addRow(): void {
     selectedProducts.value.push(undefined);
 }
 
-function removeRow(index: number): void {
-    if (!confirm(t('estimations.create.confirmRemoveRow'))) {
+async function removeRow(index: number): Promise<void> {
+    if (!(await confirmDialog(t('estimations.create.confirmRemoveRow')))) {
         return;
     }
 
@@ -164,8 +165,8 @@ function submit(): void {
     form.put(EstimationController.update(props.estimation.id).url);
 }
 
-function onDelete(): void {
-    if (confirm(t('estimations.edit.confirmDelete'))) {
+async function onDelete(): Promise<void> {
+    if (await confirmDialog(t('estimations.edit.confirmDelete'))) {
         router.delete(EstimationController.destroy(props.estimation.id).url);
     }
 }
@@ -192,8 +193,10 @@ function onFileSelected(event: Event): void {
     (event.target as HTMLInputElement).value = '';
 }
 
-function deleteAttachment(attachmentId: string): void {
-    if (!confirm(t('estimations.edit.attachments.confirmDelete'))) {
+async function deleteAttachment(attachmentId: string): Promise<void> {
+    if (
+        !(await confirmDialog(t('estimations.edit.attachments.confirmDelete')))
+    ) {
         return;
     }
 

--- a/resources/js/pages/invoices/Create.vue
+++ b/resources/js/pages/invoices/Create.vue
@@ -19,6 +19,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { confirmDialog } from '@/lib/confirmDialog';
 import { addDurationToDate } from '@/lib/productDuration';
 import { index } from '@/routes/invoices';
 import type { BreadcrumbItem } from '@/types';
@@ -43,6 +44,7 @@ const props = defineProps<{
         customer_id: string;
         note: string | null;
         language: string;
+        type: string;
         rows: InvoiceRowForm[];
     } | null;
 }>();
@@ -62,6 +64,7 @@ const form = useForm({
     customer_id: props.duplicate?.customer_id ?? '',
     note: props.duplicate?.note ?? '',
     language: props.duplicate?.language ?? 'es',
+    type: props.duplicate?.type ?? 'invoice',
     rows: props.duplicate?.rows ?? [
         {
             description: '',
@@ -88,8 +91,8 @@ function addRow(): void {
     selectedProducts.value.push(undefined);
 }
 
-function removeRow(index: number): void {
-    if (!confirm(t('invoices.create.confirmRemoveRow'))) {
+async function removeRow(index: number): Promise<void> {
+    if (!(await confirmDialog(t('invoices.create.confirmRemoveRow')))) {
         return;
     }
 
@@ -223,6 +226,28 @@ function submit(): void {
                         </SelectContent>
                     </Select>
                     <InputError :message="form.errors.language" />
+                </div>
+            </div>
+
+            <div class="grid grid-cols-2 gap-4">
+                <div class="grid gap-2">
+                    <Label for="type">{{ t('invoices.create.type') }}</Label>
+                    <Select v-model="form.type">
+                        <SelectTrigger id="type" class="w-full">
+                            <SelectValue
+                                :placeholder="t('invoices.create.selectType')"
+                            />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="invoice">
+                                {{ t('invoices.type.invoice') }}
+                            </SelectItem>
+                            <SelectItem value="credit_note">
+                                {{ t('invoices.type.credit_note') }}
+                            </SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <InputError :message="form.errors.type" />
                 </div>
             </div>
 

--- a/resources/js/pages/invoices/Edit.vue
+++ b/resources/js/pages/invoices/Edit.vue
@@ -19,6 +19,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { confirmDialog } from '@/lib/confirmDialog';
 import { addDurationToDate } from '@/lib/productDuration';
 import { index } from '@/routes/invoices';
 import type { BreadcrumbItem } from '@/types';
@@ -49,6 +50,7 @@ type Invoice = {
     company_id: string;
     note: string | null;
     language: string;
+    type: string;
     rows: InvoiceRow[];
 };
 
@@ -82,6 +84,7 @@ const form = useForm({
     customer_id: props.invoice.customer_id,
     note: props.invoice.note ?? '',
     language: props.invoice.language,
+    type: props.invoice.type,
     rows: props.invoice.rows.map((row) => ({
         id: row.id,
         description: row.description,
@@ -108,8 +111,8 @@ function addRow(): void {
     selectedProducts.value.push(undefined);
 }
 
-function removeRow(index: number): void {
-    if (!confirm(t('invoices.create.confirmRemoveRow'))) {
+async function removeRow(index: number): Promise<void> {
+    if (!(await confirmDialog(t('invoices.create.confirmRemoveRow')))) {
         return;
     }
 
@@ -169,8 +172,8 @@ function submit(): void {
     form.put(InvoiceController.update(props.invoice.id).url);
 }
 
-function onDelete(): void {
-    if (confirm(t('invoices.edit.confirmDelete'))) {
+async function onDelete(): Promise<void> {
+    if (await confirmDialog(t('invoices.edit.confirmDelete'))) {
         router.delete(InvoiceController.destroy(props.invoice.id).url);
     }
 }
@@ -285,6 +288,28 @@ function onDelete(): void {
                         </SelectContent>
                     </Select>
                     <InputError :message="form.errors.language" />
+                </div>
+            </div>
+
+            <div class="grid grid-cols-2 gap-4">
+                <div class="grid gap-2">
+                    <Label for="type">{{ t('invoices.create.type') }}</Label>
+                    <Select v-model="form.type">
+                        <SelectTrigger id="type" class="w-full">
+                            <SelectValue
+                                :placeholder="t('invoices.create.selectType')"
+                            />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="invoice">
+                                {{ t('invoices.type.invoice') }}
+                            </SelectItem>
+                            <SelectItem value="credit_note">
+                                {{ t('invoices.type.credit_note') }}
+                            </SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <InputError :message="form.errors.type" />
                 </div>
             </div>
 

--- a/resources/js/pages/invoices/Index.vue
+++ b/resources/js/pages/invoices/Index.vue
@@ -17,6 +17,7 @@ type Invoice = {
     invoice_date: string;
     paid: boolean;
     total: string | number;
+    type: string;
     customer: { id: string; name: string } | null;
 };
 
@@ -56,6 +57,10 @@ function onSearch(): void {
 
 function formatTotal(total: string | number): string {
     return Number(total).toFixed(2);
+}
+
+function typeLabel(type: string): string {
+    return t(`invoices.type.${type}`);
 }
 
 function formatDate(date: string): string {
@@ -103,6 +108,9 @@ function formatDate(date: string): string {
                             {{ t('invoices.index.columns.customer') }}
                         </th>
                         <th class="px-4 py-2 font-medium">
+                            {{ t('invoices.index.columns.type') }}
+                        </th>
+                        <th class="px-4 py-2 font-medium">
                             {{ t('invoices.index.columns.paid') }}
                         </th>
                         <th class="px-4 py-2 font-medium">
@@ -123,6 +131,17 @@ function formatDate(date: string): string {
                         </td>
                         <td class="px-4 py-2">
                             {{ invoice.customer?.name ?? '—' }}
+                        </td>
+                        <td class="px-4 py-2">
+                            <Badge
+                                :variant="
+                                    invoice.type === 'credit_note'
+                                        ? 'secondary'
+                                        : 'outline'
+                                "
+                            >
+                                {{ typeLabel(invoice.type) }}
+                            </Badge>
                         </td>
                         <td class="px-4 py-2">
                             <Badge
@@ -202,7 +221,7 @@ function formatDate(date: string): string {
                     </tr>
                     <tr v-if="invoices.data.length === 0">
                         <td
-                            colspan="6"
+                            colspan="7"
                             class="px-4 py-6 text-center text-muted-foreground"
                         >
                             {{ t('invoices.index.empty') }}

--- a/resources/js/pages/products/Edit.vue
+++ b/resources/js/pages/products/Edit.vue
@@ -14,6 +14,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { confirmDialog } from '@/lib/confirmDialog';
 import { index } from '@/routes/products';
 import type { BreadcrumbItem } from '@/types';
 
@@ -38,8 +39,8 @@ setLayoutProps({
     ] satisfies BreadcrumbItem[],
 });
 
-function onDelete(): void {
-    if (confirm(t('products.edit.confirmDelete'))) {
+async function onDelete(): Promise<void> {
+    if (await confirmDialog(t('products.edit.confirmDelete'))) {
         router.delete(ProductController.destroy(props.product.id).url);
     }
 }

--- a/resources/lang/en/invoice.php
+++ b/resources/lang/en/invoice.php
@@ -2,6 +2,7 @@
 
 return [
     'title' => 'Invoice',
+    'credit_note_title' => 'Credit Note',
     'number' => 'Number',
     'date' => 'Date',
     'customer' => 'Customer',

--- a/resources/lang/es/invoice.php
+++ b/resources/lang/es/invoice.php
@@ -2,6 +2,7 @@
 
 return [
     'title' => 'Factura',
+    'credit_note_title' => 'Nota de Crédito',
     'number' => 'Número',
     'date' => 'Fecha',
     'customer' => 'Cliente',

--- a/resources/lang/it/invoice.php
+++ b/resources/lang/it/invoice.php
@@ -2,6 +2,7 @@
 
 return [
     'title' => 'Fattura',
+    'credit_note_title' => 'Nota di Credito',
     'number' => 'Numero',
     'date' => 'Data',
     'customer' => 'Cliente',

--- a/resources/views/invoices/template.blade.php
+++ b/resources/views/invoices/template.blade.php
@@ -3,12 +3,13 @@
     $logoData = $logoPath && file_exists($logoPath)
         ? 'data:' . mime_content_type($logoPath) . ';base64,' . base64_encode(file_get_contents($logoPath))
         : null;
+    $documentTitle = $invoice->isCreditNote() ? __('invoice.credit_note_title') : __('invoice.title');
 @endphp
 <!DOCTYPE html>
 <html lang="{{ $invoice->language }}">
 <head>
     <meta charset="utf-8">
-    <title>{{ __('invoice.title') }} {{ $invoice->number }}</title>
+    <title>{{ $documentTitle }} {{ $invoice->number }}</title>
     <style>
         body { font-family: Helvetica, Arial, sans-serif; font-size: 12px; color: #1f2937; margin: 40px; }
         table { border-collapse: collapse; }
@@ -70,7 +71,7 @@
                 </div>
             </td>
             <td class="meta">
-                <h1>{{ __('invoice.title') }}</h1>
+                <h1>{{ $documentTitle }}</h1>
                 <div>{{ __('invoice.number') }}: {{ $invoice->number }}</div>
                 <div>{{ __('invoice.date') }}: {{ $invoice->invoice_date->format('d/m/Y') }}</div>
             </td>

--- a/tests/Feature/InvoiceTemplateTest.php
+++ b/tests/Feature/InvoiceTemplateTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\InvoiceType;
 use App\Models\Invoice;
 use App\Models\InvoiceRow;
 use Illuminate\Support\Facades\App;
@@ -62,6 +63,15 @@ test('template omits the notes section when the invoice has no note', function (
     $html = renderInvoiceTemplate($invoice);
 
     expect($html)->not->toContain('id="notes"');
+});
+
+test('template shows the credit note title for credit note invoices', function () {
+    $invoice = Invoice::factory()->create(['language' => 'en', 'type' => InvoiceType::CreditNote]);
+    InvoiceRow::factory()->create(['invoice_id' => $invoice->id]);
+
+    $html = renderInvoiceTemplate($invoice);
+
+    expect($html)->toContain('Credit Note');
 });
 
 test('template renders the quantity column for each row', function () {

--- a/tests/Feature/InvoiceTest.php
+++ b/tests/Feature/InvoiceTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\InvoiceType;
 use App\Models\Company;
 use App\Models\Customer;
 use App\Models\Invoice;
@@ -142,6 +143,18 @@ test('invoice row total accessor multiplies price by quantity before applying va
     $row = InvoiceRow::factory()->create(['quantity' => 2, 'price' => 100, 'vat_rate' => 22]);
 
     expect((float) $row->total)->toEqual(244.0);
+});
+
+test('invoice factory defaults to invoice type', function () {
+    $invoice = Invoice::factory()->create();
+
+    expect($invoice->type)->toBe(InvoiceType::Invoice);
+});
+
+test('invoice factory can create a credit note', function () {
+    $invoice = Invoice::factory()->creditNote()->create();
+
+    expect($invoice->type)->toBe(InvoiceType::CreditNote);
 });
 
 use App\Enums\SubscriptionStatus;
@@ -315,6 +328,118 @@ test('a number already used by another company passes validation', function () {
     ]);
 
     $response->assertSessionHasNoErrors()->assertRedirect(route('invoices.index'));
+});
+
+test('invoice store request requires a valid type when provided', function () {
+    $user = User::factory()->create();
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $response = $this->actingAs($user)->withSession(['current_company_id' => $company->id])->post(route('invoices.store'), [
+        'invoice_date' => '2026-01-15',
+        'customer_id' => $customer->id,
+        'language' => 'en',
+        'type' => 'bogus',
+        'rows' => [
+            ['description' => 'Consulting', 'quantity' => 1, 'price' => 100, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertSessionHasErrors('type');
+});
+
+test('creating an invoice without a type defaults to invoice', function () {
+    $user = User::factory()->create();
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $this->actingAs($user)->withSession(['current_company_id' => $company->id])->post(route('invoices.store'), [
+        'invoice_date' => '2026-01-15',
+        'customer_id' => $customer->id,
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Consulting', 'quantity' => 1, 'price' => 100, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $invoice = Invoice::query()->where('customer_id', $customer->id)->firstOrFail();
+    expect($invoice->type)->toBe(InvoiceType::Invoice);
+});
+
+test('creating a credit note stores row prices as negative and totals negative', function () {
+    $user = User::factory()->create();
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $this->actingAs($user)->withSession(['current_company_id' => $company->id])->post(route('invoices.store'), [
+        'invoice_date' => '2026-01-15',
+        'customer_id' => $customer->id,
+        'language' => 'en',
+        'type' => 'credit_note',
+        'rows' => [
+            ['description' => 'Refund', 'quantity' => 1, 'price' => 100, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $invoice = Invoice::query()->where('customer_id', $customer->id)->firstOrFail();
+    expect($invoice->type)->toBe(InvoiceType::CreditNote);
+    expect((float) $invoice->rows->first()->price)->toEqual(-100.0);
+    expect((float) $invoice->subtotal)->toEqual(-100.0);
+    expect((float) $invoice->total)->toEqual(-122.0);
+});
+
+test('updating an invoice to a credit note negates its row prices', function () {
+    $user = User::factory()->create();
+    $company = Company::factory()->create();
+    $invoice = Invoice::factory()->create(['company_id' => $company->id, 'type' => InvoiceType::Invoice]);
+    $row = InvoiceRow::factory()->create(['invoice_id' => $invoice->id, 'quantity' => 1, 'price' => 50, 'vat_rate' => 10]);
+
+    $response = $this->actingAs($user)->withSession(['current_company_id' => $company->id])->put(route('invoices.update', $invoice), [
+        'number' => $invoice->number,
+        'invoice_date' => $invoice->invoice_date->format('Y-m-d'),
+        'paid' => $invoice->paid,
+        'customer_id' => $invoice->customer_id,
+        'language' => $invoice->language,
+        'type' => 'credit_note',
+        'rows' => [
+            ['id' => $row->id, 'description' => $row->description, 'quantity' => 1, 'price' => 50, 'vat_rate' => 10],
+        ],
+    ]);
+
+    $response->assertSessionHasNoErrors();
+    expect($invoice->fresh()->type)->toBe(InvoiceType::CreditNote);
+    expect((float) $row->fresh()->price)->toEqual(-50.0);
+});
+
+test('invoice edit page shows credit note row prices as positive even though they are stored negative', function () {
+    $user = User::factory()->create();
+    $company = Company::factory()->create();
+    $invoice = Invoice::factory()->create(['company_id' => $company->id, 'type' => InvoiceType::CreditNote]);
+    InvoiceRow::factory()->create(['invoice_id' => $invoice->id, 'price' => -75, 'quantity' => 1]);
+
+    $response = $this->actingAs($user)->withSession(['current_company_id' => $company->id])->get(route('invoices.edit', $invoice));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('invoices/Edit')
+        ->where('invoice.rows.0.price', 75)
+    );
+});
+
+test('duplicating a credit note carries over its type and shows positive row prices', function () {
+    $user = User::factory()->create();
+    $currentCompany = Company::factory()->create();
+    $source = Invoice::factory()->create(['company_id' => $currentCompany->id, 'type' => InvoiceType::CreditNote]);
+    InvoiceRow::factory()->create(['invoice_id' => $source->id, 'price' => -40, 'quantity' => 1]);
+
+    $response = $this->actingAs($user)->withSession(['current_company_id' => $currentCompany->id])->get(route('invoices.create', ['duplicate' => $source->id]));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('invoices/Create')
+        ->where('duplicate.type', 'credit_note')
+        ->where('duplicate.rows.0.price', 40)
+    );
 });
 
 test('invoice requires at least one row', function () {


### PR DESCRIPTION
## Summary
- Invoices now support a `type`: **Invoice** (default) or **Credit Note**, sharing the same sequential numbering. Row amounts are entered as positive numbers and stored negative for credit notes (so totals come out negative too); editing/duplicating shows them back as positive. The PDF/preview title switches accordingly.
- Every destructive action across the app (delete invoice/company/customer/product/estimate/attachment, remove an invoice/estimate row, cancel a recurring service) now goes through a shared in-app confirmation modal (`ConfirmDialog.vue` + `lib/confirmDialog.ts`) instead of the browser's native `confirm()`.
- Docs: README.md, DATABASE.md and the wiki (Home, Invoices, Architecture/Architettura) updated for both features.
- Added `@playwright/test` as a dev dependency, used to visually verify both features end-to-end (login, real click-through, screenshots) rather than relying on type-check/build alone.

## Test plan
- [x] Full Pest suite green (316 tests, 1085 assertions)
- [x] Pint, vue-tsc, ESLint, Prettier, `npm run build` all clean
- [x] Manual Playwright walkthrough against disposable test data: invoice type select (Invoice/Credit Note), and the confirm dialog on invoice delete (Cancel preserves the invoice, Confirm deletes it and redirects) — no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
