### PR TITLE
Add rootless Docker support (arbitrary UID + GID 0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY docker/php/local.ini /etc/php/${PHP_VERSION}/fpm/conf.d/99-local.ini
 COPY docker/php/local.ini /etc/php/${PHP_VERSION}/cli/conf.d/99-local.ini
 COPY docker/php/www.conf /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf
+COPY docker/php/www-rootless.conf /etc/php/${PHP_VERSION}/fpm/pool.d/www-rootless.conf.available
 
 WORKDIR /app
 
@@ -72,6 +73,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         supervisor \
         certbot \
         openssl \
+        gettext-base \
+        libnss-wrapper \
     && rm -rf /var/lib/apt/lists/*
 
 COPY docker/nginx/app.conf /etc/nginx/sites-available/app.conf
@@ -90,10 +93,15 @@ COPY docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 RUN chmod +x /usr/local/bin/healthcheck.sh
 
 RUN mkdir -p storage/framework/{cache,sessions,testing,views} storage/logs bootstrap/cache \
+        /data /certs /var/www/certbot /etc/nginx/certs \
     && chown -R www-data:www-data /app storage bootstrap/cache \
-    && chmod -R 775 storage bootstrap/cache
+    && chmod -R 775 storage bootstrap/cache \
+    && chgrp -R 0 /app /data /certs /var/www/certbot /etc/nginx/certs /run /var/lib/nginx /var/log/nginx \
+        /etc/nginx/sites-available /etc/nginx/sites-enabled "/etc/php/${PHP_VERSION}/fpm/pool.d" \
+    && chmod -R g=u /app /data /certs /var/www/certbot /etc/nginx/certs /run /var/lib/nginx /var/log/nginx \
+        /etc/nginx/sites-available /etc/nginx/sites-enabled "/etc/php/${PHP_VERSION}/fpm/pool.d"
 
-EXPOSE 80 443
+EXPOSE 80 443 8080 8443
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD ["/usr/local/bin/healthcheck.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,9 +96,9 @@ RUN mkdir -p storage/framework/{cache,sessions,testing,views} storage/logs boots
         /data /certs /var/www/certbot /etc/nginx/certs \
     && chown -R www-data:www-data /app storage bootstrap/cache \
     && chmod -R 775 storage bootstrap/cache \
-    && chgrp -R 0 /app /data /certs /var/www/certbot /etc/nginx/certs /run /var/lib/nginx /var/log/nginx \
+    && chgrp -R 0 /app /data /certs /var/www/certbot /etc/nginx/certs /run /var/lib/nginx /var/log \
         /etc/nginx/sites-available /etc/nginx/sites-enabled "/etc/php/${PHP_VERSION}/fpm/pool.d" \
-    && chmod -R g=u /app /data /certs /var/www/certbot /etc/nginx/certs /run /var/lib/nginx /var/log/nginx \
+    && chmod -R g=u /app /data /certs /var/www/certbot /etc/nginx/certs /run /var/lib/nginx /var/log \
         /etc/nginx/sites-available /etc/nginx/sites-enabled "/etc/php/${PHP_VERSION}/fpm/pool.d"
 
 EXPOSE 80 443 8080 8443

--- a/README.md
+++ b/README.md
@@ -63,6 +63,38 @@ HTTPS is served on `${APP_HTTPS_PORT:-8443}` (host) → `:443` (container).
 
 `certbot` and `custom` require a real `APP_URL` set in `.env` (not the default `http://localhost:8080`), since the certificate domain is derived from its host.
 
+### Running rootless
+
+The image auto-detects whether it's running as root or as an arbitrary
+non-root UID and adjusts itself accordingly — no build flag needed. When
+started as a non-root UID:
+
+- Listen ports switch from `80`/`443` to `8080`/`8443` (unprivileged ports
+  don't require `CAP_NET_BIND_SERVICE`).
+- Ownership fixups (`chown`) are skipped in favor of group-writable
+  permissions baked into the image at build time, following the OpenShift
+  arbitrary-UID convention: the container's runtime GID must be **0** (as a
+  primary or supplementary group), either supplementary or primary.
+- A synthetic `/etc/passwd` entry is generated via `nss_wrapper` for UIDs
+  that don't already have one, so `getpwuid()`-dependent tooling (OpenSSL,
+  Certbot, some PHP extensions) keeps working.
+
+Example with plain `docker run`:
+
+```bash
+docker run --user 1000:0 -p 8080:8080 -p 8443:8443 --env-file .env simonecosci/biglins
+```
+
+On Kubernetes/OpenShift, set `securityContext.runAsUser` to any UID and
+`securityContext.runAsGroup: 0` (OpenShift's default restricted SCC does
+this automatically, so most deployments need no `securityContext` at all).
+
+**Caveat:** for `storage`/`database`/`certs` backed by a fresh Docker/Podman
+named volume, the image's baked permissions carry over automatically on
+first mount. Kubernetes PersistentVolumeClaims don't get this treatment —
+if your storage provisioner doesn't already grant group-0 write access,
+set a matching `fsGroup` in the pod's `securityContext`.
+
 ## Useful commands
 
 | Command | Description |

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -32,19 +32,20 @@ if [ "$IS_ROOT" != "1" ]; then
     fi
 fi
 
-# Create a dir and, when non-root, guarantee it's group-writable regardless
-# of umask. For dirs the process just created, it owns them and this chmod
-# always succeeds. For dirs that pre-exist from the image (owned by
-# www-data, group 0 already made writable at build time per Task 4), a
-# non-owning UID cannot chmod them even though it can already write into
-# them — chmod requires file ownership, not just group write access.
-# Failure is expected and harmless in that case (the baked group-write bit
-# already provides what we need), so stderr is discarded and the exit
-# status ignored rather than letting `set -e` abort startup or `chmod -R`
-# spam one "Operation not permitted" line per file it recurses into.
+# Create a dir and, when non-root and the process owns it, guarantee it's
+# group-writable regardless of umask. For dirs the process just created, it
+# owns them, so the chmod applies and is expected to succeed under `set -e`.
+# For dirs that pre-exist from the image (owned by www-data, group 0 already
+# made writable at build time per Task 4), a non-owning UID cannot chmod
+# them even though it can already write into them — chmod requires file
+# ownership, not just group write access — so the chmod is skipped entirely
+# rather than attempted-and-swallowed; the baked group-write bit already
+# provides what's needed there.
 ensure_writable_dir() {
     mkdir -p "$1"
-    [ "$IS_ROOT" = "1" ] || chmod -R g+rwX "$1" >/dev/null 2>&1 || true
+    if [ "$IS_ROOT" != "1" ] && [ "$(stat -c %u "$1")" = "$CURRENT_UID" ]; then
+        chmod -R g+rwX "$1"
+    fi
 }
 
 ensure_writable_dir storage/framework/cache

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,16 +3,65 @@ set -e
 
 cd /app
 
-mkdir -p storage/framework/{cache,sessions,testing,views} storage/logs bootstrap/cache
-chown -R www-data:www-data storage bootstrap/cache
+IS_ROOT=0
+[ "$(id -u)" = "0" ] && IS_ROOT=1
 
-mkdir -p /run/php
-chown www-data:www-data /run/php
+if [ "$IS_ROOT" = "1" ]; then
+    HTTP_PORT="${HTTP_PORT:-80}"
+    HTTPS_PORT="${HTTPS_PORT:-443}"
+else
+    HTTP_PORT="${HTTP_PORT:-8080}"
+    HTTPS_PORT="${HTTPS_PORT:-8443}"
+fi
+export HTTP_PORT HTTPS_PORT
+
+# --- rootless support: synthesize a passwd/group entry via nss_wrapper ------
+# Arbitrary UIDs assigned by Kubernetes/OpenShift have no /etc/passwd entry,
+# which breaks getpwuid()-dependent tooling (openssl, some PHP extensions).
+if [ "$IS_ROOT" != "1" ]; then
+    CURRENT_UID="$(id -u)"
+    CURRENT_GID="$(id -g)"
+    if ! getent passwd "$CURRENT_UID" >/dev/null 2>&1; then
+        export NSS_WRAPPER_PASSWD=/tmp/nss-wrapper-passwd
+        export NSS_WRAPPER_GROUP=/tmp/nss-wrapper-group
+        cp /etc/passwd "$NSS_WRAPPER_PASSWD"
+        cp /etc/group "$NSS_WRAPPER_GROUP"
+        echo "appuser:x:${CURRENT_UID}:${CURRENT_GID}:App User:/tmp:/bin/false" >> "$NSS_WRAPPER_PASSWD"
+        getent group "$CURRENT_GID" >/dev/null 2>&1 || echo "appuser:x:${CURRENT_GID}:" >> "$NSS_WRAPPER_GROUP"
+        export LD_PRELOAD="libnss_wrapper.so"
+    fi
+fi
+
+# Create a dir and, when non-root, guarantee it's group-writable regardless
+# of umask. For dirs the process just created, it owns them and this chmod
+# always succeeds. For dirs that pre-exist from the image (owned by
+# www-data, group 0 already made writable at build time per Task 4), a
+# non-owning UID cannot chmod them even though it can already write into
+# them — chmod requires file ownership, not just group write access.
+# Failure is expected and harmless in that case (the baked group-write bit
+# already provides what we need), so stderr is discarded and the exit
+# status ignored rather than letting `set -e` abort startup or `chmod -R`
+# spam one "Operation not permitted" line per file it recurses into.
+ensure_writable_dir() {
+    mkdir -p "$1"
+    [ "$IS_ROOT" = "1" ] || chmod -R g+rwX "$1" >/dev/null 2>&1 || true
+}
+
+ensure_writable_dir storage/framework/cache
+ensure_writable_dir storage/framework/sessions
+ensure_writable_dir storage/framework/testing
+ensure_writable_dir storage/framework/views
+ensure_writable_dir storage/logs
+ensure_writable_dir bootstrap/cache
+[ "$IS_ROOT" = "1" ] && chown -R www-data:www-data storage bootstrap/cache
+
+ensure_writable_dir /run/php
+[ "$IS_ROOT" = "1" ] && chown www-data:www-data /run/php
 
 if [ "$DB_CONNECTION" = "sqlite" ] && [ -n "$DB_DATABASE" ]; then
-    mkdir -p "$(dirname "$DB_DATABASE")"
+    ensure_writable_dir "$(dirname "$DB_DATABASE")"
     [ -f "$DB_DATABASE" ] || touch "$DB_DATABASE"
-    chown -R www-data:www-data "$(dirname "$DB_DATABASE")"
+    [ "$IS_ROOT" = "1" ] && chown -R www-data:www-data "$(dirname "$DB_DATABASE")"
 fi
 
 if [ -z "$APP_KEY" ]; then
@@ -28,13 +77,29 @@ php artisan route:cache
 php artisan view:cache
 php artisan storage:link || true
 
-chown -R www-data:www-data storage bootstrap/cache
+[ "$IS_ROOT" = "1" ] && chown -R www-data:www-data storage bootstrap/cache
 
-# --- SSL certificate setup --------------------------------------------------
-# Only provision certificates when this invocation actually starts the server
-# process tree (the image's default CMD). One-off `docker compose run ...`
-# commands skip straight to `exec "$@"`.
+# --- SSL certificate setup + nginx/php-fpm runtime config -------------------
+# Only provision certificates and render server config when this invocation
+# actually starts the server process tree (the image's default CMD). One-off
+# `docker compose run ...` commands skip straight to `exec "$@"`.
 if [ "$1" = "/usr/bin/supervisord" ]; then
+    if [ "$IS_ROOT" != "1" ]; then
+        cp "/etc/php/${PHP_VERSION}/fpm/pool.d/www-rootless.conf.available" \
+            "/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf"
+    fi
+
+    for conf in app.conf app-ssl-http.conf app-ssl-https.conf; do
+        envsubst '${HTTP_PORT} ${HTTPS_PORT}' \
+            < "/etc/nginx/sites-available/$conf" > "/tmp/$conf"
+        mv "/tmp/$conf" "/etc/nginx/sites-available/$conf"
+    done
+
+    {
+        echo "HTTP_PORT=$HTTP_PORT"
+        echo "HTTPS_PORT=$HTTPS_PORT"
+    } > /run/app-ports.env
+
     SSL_MODE="${SSL_MODE:-none}"
     CERTS_DIR=/certs
     NGINX_CERT_DIR=/etc/nginx/certs
@@ -43,7 +108,7 @@ if [ "$1" = "/usr/bin/supervisord" ]; then
 
     DOMAIN=$(echo "$APP_URL" | sed -E 's#^[a-zA-Z]+://##; s#[:/].*$##')
 
-    mkdir -p "$NGINX_CERT_DIR"
+    ensure_writable_dir "$NGINX_CERT_DIR"
 
     enable_http_only() {
         rm -f "$SITES_ENABLED"/app.conf "$SITES_ENABLED"/app-ssl-http.conf "$SITES_ENABLED"/app-ssl-https.conf
@@ -61,7 +126,7 @@ if [ "$1" = "/usr/bin/supervisord" ]; then
             enable_http_only
             ;;
         selfsigned)
-            mkdir -p "$CERTS_DIR/selfsigned"
+            ensure_writable_dir "$CERTS_DIR/selfsigned"
             if [ ! -f "$CERTS_DIR/selfsigned/fullchain.pem" ]; then
                 openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
                     -keyout "$CERTS_DIR/selfsigned/privkey.pem" \
@@ -88,7 +153,8 @@ if [ "$1" = "/usr/bin/supervisord" ]; then
                 exit 1
             fi
             LE_DIR="$CERTS_DIR/letsencrypt"
-            mkdir -p "$LE_DIR" /var/www/certbot
+            ensure_writable_dir "$LE_DIR"
+            ensure_writable_dir /var/www/certbot
             if [ ! -f "$LE_DIR/live/$DOMAIN/fullchain.pem" ]; then
                 rm -f "$SITES_ENABLED"/app.conf "$SITES_ENABLED"/app-ssl-http.conf "$SITES_ENABLED"/app-ssl-https.conf
                 ln -sf "$SITES_AVAILABLE"/app-ssl-http.conf "$SITES_ENABLED"/app-ssl-http.conf

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,6 +6,30 @@ cd /app
 IS_ROOT=0
 [ "$(id -u)" = "0" ] && IS_ROOT=1
 
+if [ "$IS_ROOT" != "1" ]; then
+    # Rootless support is scoped to arbitrary UID + GID 0 (primary or
+    # supplementary), per the design. Fail fast and loudly here rather than
+    # letting nginx/php-fpm silently fail to open their log files later
+    # (which otherwise manifests as unexplained 502s with nothing in the
+    # log naming the real cause).
+    case " $(id -G) " in
+        *" 0 "*) ;;
+        *)
+            echo "ERROR: rootless mode requires GID 0 (primary or supplementary group); got groups: $(id -G). Use --user <uid>:0, or set securityContext.runAsGroup: 0 on Kubernetes/OpenShift." >&2
+            exit 1
+            ;;
+    esac
+
+    # Runtime-created files/dirs (sqlite db, cache files, logs, certs, etc.)
+    # must be group-writable so the arbitrary-UID contract survives a later
+    # UID change against a persisted volume (e.g. an OpenShift namespace
+    # recreate, or a PVC restored into a different cluster). Docker's
+    # default umask (0022) would otherwise strip the group-write bit from
+    # everything created at runtime. Root-mode behavior must stay
+    # byte-for-byte unchanged, so this is confined to the non-root branch.
+    umask 0002
+fi
+
 if [ "$IS_ROOT" = "1" ]; then
     HTTP_PORT="${HTTP_PORT:-80}"
     HTTPS_PORT="${HTTPS_PORT:-443}"
@@ -44,7 +68,7 @@ fi
 ensure_writable_dir() {
     mkdir -p "$1"
     if [ "$IS_ROOT" != "1" ] && [ "$(stat -c %u "$1")" = "$CURRENT_UID" ]; then
-        chmod -R g+rwX "$1"
+        chmod g+rwX "$1"
     fi
 }
 

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 set -e
 
+[ -f /run/app-ports.env ] && . /run/app-ports.env
+
+HTTP_PORT="${HTTP_PORT:-80}"
+HTTPS_PORT="${HTTPS_PORT:-443}"
 SSL_MODE="${SSL_MODE:-none}"
 
 if [ "$SSL_MODE" = "none" ]; then
-    curl -fsS http://localhost/ -o /dev/null
+    curl -fsS "http://localhost:${HTTP_PORT}/" -o /dev/null
 else
-    curl -fsSk https://localhost/ -o /dev/null
+    curl -fsSk "https://localhost:${HTTPS_PORT}/" -o /dev/null
 fi

--- a/docker/nginx/app-ssl-http.conf
+++ b/docker/nginx/app-ssl-http.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen ${HTTP_PORT};
     server_name _;
 
     location /.well-known/acme-challenge/ {

--- a/docker/nginx/app-ssl-https.conf
+++ b/docker/nginx/app-ssl-https.conf
@@ -1,5 +1,5 @@
 server {
-    listen 443 ssl;
+    listen ${HTTPS_PORT} ssl;
     server_name _;
     root /app/public;
     index index.php;

--- a/docker/nginx/app.conf
+++ b/docker/nginx/app.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen ${HTTP_PORT};
     server_name _;
     root /app/public;
     index index.php;

--- a/docker/php/www-rootless.conf
+++ b/docker/php/www-rootless.conf
@@ -1,0 +1,14 @@
+[www]
+
+listen = /run/php/php-fpm.sock
+listen.mode = 0660
+
+pm = dynamic
+pm.max_children = 10
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 4
+
+clear_env = no
+catch_workers_output = yes
+decorate_workers_output = no

--- a/docker/supervisor/supervisord.conf
+++ b/docker/supervisor/supervisord.conf
@@ -1,6 +1,5 @@
 [supervisord]
 nodaemon=true
-user=root
 logfile=/dev/null
 logfile_maxbytes=0
 pidfile=/run/supervisord.pid


### PR DESCRIPTION
## Summary

- Adds rootless support for the Docker image so it runs correctly under Podman, Kubernetes, and OpenShift's arbitrary-UID convention, in addition to the existing root-only flow.
- `docker/entrypoint.sh` auto-detects `root` vs. a non-root UID at container start and branches accordingly — no build args, no separate image variant.
- Non-root mode: switches nginx to unprivileged ports 8080/8443, skips `chown` in favor of GID-0 group-writable permissions baked into the image at build time, swaps in a php-fpm pool config without `user`/`group` directives, drops supervisord's now-unnecessary `user=root`, and synthesizes a `/etc/passwd` entry via `nss_wrapper` for UIDs with no existing one.
- Root-mode `docker-compose.yml` flow is unchanged in observable behavior.

Closes #16

## Test plan

- [x] Full Pest suite: 317/317 passing (branch touches no PHP/JS files — infra only)
- [x] Root-mode regression: `docker compose up` — HTTP 200, all supervisord programs RUNNING, no permission errors
- [x] Rootless smoke test: `docker run --user 1000:0` — HTTP 200, UID 1000/GID 0 confirmed on every process, no nss_wrapper/getpwuid/permission errors
- [x] Root-mode + `SSL_MODE=selfsigned`: HTTPS 200, cert generated
- [x] Rootless + `SSL_MODE=selfsigned`: HTTPS 200, runtime-created files confirmed group-writable (umask fix)
- [x] Fail-fast check: `--user UID:GID` with GID≠0 now exits immediately with a clear error instead of a silent 502
- [x] Design spec and implementation plan: `docs/superpowers/specs/2026-08-15-rootless-docker-support-design.md`, `docs/superpowers/plans/2026-08-15-rootless-docker-support.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)