### PR TITLE
docs: reference the estimates feature in README and app home

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![docker-publish](https://github.com/simonecosci/biglins/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/simonecosci/biglins/actions/workflows/docker-publish.yml)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Invoicing app for freelancers and sole proprietors: customer records, invoices with line items/VAT, credit notes to reverse a previous invoice, automatic sequential numbering, PDF preview and generation, invoice duplication, a renewal schedule for recurring services (domains, hosting, maintenance) with renew/cancel actions from the dashboard, and a year-to-date revenue summary.
+Invoicing app for freelancers and sole proprietors: customer records, invoices with line items/VAT, credit notes to reverse a previous invoice, automatic sequential numbering, PDF preview and generation, invoice duplication, a renewal schedule for recurring services (domains, hosting, maintenance) with renew/cancel actions from the dashboard, a year-to-date revenue summary, and estimates (quotes) with a markdown proposal, file attachments, PDF/ZIP export, and one-click conversion into an invoice once accepted.
 
 ## Stack
 

--- a/resources/js/lang/en.ts
+++ b/resources/js/lang/en.ts
@@ -208,7 +208,7 @@ const messages = {
     },
     welcome: {
         description:
-            'Invoicing application for freelancers: customer registry, invoice issuing with rows/VAT, automatic sequential numbering, PDF preview and generation, invoice duplication.',
+            'Invoicing application for freelancers: customer registry, invoice issuing with rows/VAT, automatic sequential numbering, PDF preview and generation, invoice duplication, estimates with a markdown proposal and conversion into an invoice.',
         readDocsPrefix: 'Read the',
         documentation: 'Documentation',
         dashboard: 'Dashboard',

--- a/resources/js/lang/es.ts
+++ b/resources/js/lang/es.ts
@@ -221,7 +221,7 @@ const messages: MessageSchema = {
     },
     welcome: {
         description:
-            'Aplicación de facturación para autónomos: registro de clientes, emisión de facturas con líneas/IGIC, numeración secuencial automática, vista previa y generación de PDF, duplicación de facturas.',
+            'Aplicación de facturación para autónomos: registro de clientes, emisión de facturas con líneas/IGIC, numeración secuencial automática, vista previa y generación de PDF, duplicación de facturas, presupuestos con propuesta en markdown y conversión en factura.',
         readDocsPrefix: 'Lee la',
         documentation: 'Documentación',
         dashboard: 'Panel',

--- a/resources/js/lang/it.ts
+++ b/resources/js/lang/it.ts
@@ -217,7 +217,7 @@ const messages: MessageSchema = {
     },
     welcome: {
         description:
-            'Applicazione di fatturazione per liberi professionisti: anagrafica clienti, emissione fatture con righe/IVA, numerazione progressiva automatica, anteprima e generazione PDF, duplicazione fattura.',
+            'Applicazione di fatturazione per liberi professionisti: anagrafica clienti, emissione fatture con righe/IVA, numerazione progressiva automatica, anteprima e generazione PDF, duplicazione fattura, preventivi con proposta in markdown e conversione in fattura.',
         readDocsPrefix: 'Leggi la',
         documentation: 'Documentazione',
         dashboard: 'Dashboard',


### PR DESCRIPTION
## Summary
- README and the app's public home description (it/en/es) now mention the estimates (preventivi) feature, which was missing after it shipped in #13.

## Test plan
- Docs-only change, no functional impact.