### PR TITLE
Merge develop in main

### DIFF
--- a/.claude/skills/mcp-development/SKILL.md
+++ b/.claude/skills/mcp-development/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: mcp-development
+description: "Use this skill for Laravel MCP development. Trigger when creating or editing MCP tools, resources, prompts, servers, or UI apps in Laravel projects. Covers: artisan make:mcp-* generators, routes/ai.php, Tool/Resource/Prompt/AppResource classes, schema validation, shouldRegister(), OAuth setup, URI templates, read-only attributes, MCP debugging, MCP UI apps, the x-mcp::app Blade component, createMcpApp(), default AppResource handle() auto-infers view from class name, Response::view(), AppMeta/Csp/Permissions/appMeta() configuration, #[RendersApp] attribute, Library enum for CDN libraries (Tailwind, Alpine), and host theming via CSS variables. Use this whenever the user mentions MCP apps, MCP UI, interactive MCP resources, styling MCP apps with Tailwind or Alpine, or building visual interfaces for AI agents."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# MCP Development
+
+## Documentation
+
+Use `search-docs` for detailed Laravel MCP patterns and documentation.
+
+For MCP UI apps (interactive HTML resources), read `references/app.md` — it covers the full architecture, host theming CSS variables, tool-to-UI linking patterns, library scripts (Tailwind, Alpine via `Library`), and real-world examples.
+
+## Basic Usage
+
+Register MCP servers in `routes/ai.php`:
+
+<!-- Register MCP Server -->
+```php
+use Laravel\Mcp\Facades\Mcp;
+
+Mcp::web();
+```
+
+### Creating MCP Primitives
+
+```bash
+php artisan make:mcp-tool ToolName            # Create a tool
+
+php artisan make:mcp-resource ResourceName     # Create a resource
+
+php artisan make:mcp-prompt PromptName        # Create a prompt
+
+php artisan make:mcp-server ServerName        # Create a server
+
+php artisan make:mcp-app-resource DashboardApp # Create a UI app (2 files)
+
+```
+
+After creating primitives, register them in your server's `$tools`, `$resources`, or `$prompts` properties.
+
+### Tools
+
+<!-- MCP Tool Example -->
+```php
+use Illuminate\Json\Schema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+class MyTool extends Tool
+{
+    protected string $description = 'Describe what this tool does';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'name' => $schema->string()->description('The name parameter')->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $request->validate(['name' => 'required|string']);
+
+        return Response::text('Hello, '.$request->get('name'));
+    }
+}
+```
+
+### Registering Primitives in a Server
+
+<!-- Register Primitives in MCP Server -->
+```php
+use Laravel\Mcp\Server;
+
+class AppServer extends Server
+{
+    protected array $tools = [
+        \App\Mcp\Tools\MyTool::class,
+    ];
+
+    protected array $resources = [
+        \App\Mcp\Resources\MyResource::class,
+    ];
+
+    protected array $prompts = [
+        \App\Mcp\Prompts\MyPrompt::class,
+    ];
+}
+```
+
+## MCP UI Apps
+
+For MCP UI apps, read `references/app.md` — it covers quick start examples, full architecture, AppMeta/Csp/Permissions, `#[RendersApp]` tool linking, library scripts (Tailwind/Alpine via `Library`), host theming CSS variables, and real-world patterns.
+
+## Verification
+
+1. Check `routes/ai.php` for proper registration
+2. Test tool via MCP client
+
+## Common Pitfalls
+
+- Running `mcp:start` command (it hangs waiting for input)
+- Using HTTPS locally with Node-based MCP clients
+- Not using `search-docs` for the latest MCP documentation
+- Not registering MCP server routes in `routes/ai.php`
+- Do not register `ai.php` in `bootstrap.php`; it is registered automatically
+- OAuth registration supports custom URI schemes (e.g., `cursor://`, `vscode://`) for native desktop clients via `mcp.custom_schemes` config

--- a/.claude/skills/mcp-development/references/app.md
+++ b/.claude/skills/mcp-development/references/app.md
@@ -1,0 +1,940 @@
+# MCP UI Apps Reference
+
+## Quick Start
+
+`make:mcp-app-resource DashboardApp` generates two files — a PHP registration stub and a Blade view. The entire app lives in the Blade view.
+
+**PHP class** — renders the Blade view. The view name is auto-inferred from the class name (`mcp.<kebab-class-name>`), so the generated stub needs no changes unless you're passing additional server-side data:
+
+```php
+class DashboardApp extends AppResource
+{
+    public function handle(Request $request): Response
+    {
+        return Response::view('mcp.dashboard-app', [
+            'title' => $this->title(),
+        ]);
+    }
+}
+```
+
+**Blade view** — HTML structure + inline JS, everything in one file:
+
+```blade
+<x-mcp::app title="Dashboard App">
+    <x-slot:head>
+        <script type="module">
+        createMcpApp(async (app) => {
+            document.getElementById('run-btn').addEventListener('click', async () => {
+                const result = await app.callServerTool({ name: 'tool-name', arguments: {} });
+                document.getElementById('output').textContent = result.content[0]?.text ?? '';
+            });
+        });
+        </script>
+    </x-slot:head>
+
+    <div id="app">
+        <h1>Dashboard App</h1>
+        <button id="run-btn">Run</button>
+        <p id="output"></p>
+    </div>
+</x-mcp::app>
+```
+
+`createMcpApp` is a global pre-bundled by the package — no npm install, no imports, no Vite required. It handles connection, error handling, and host theming automatically.
+
+---
+
+## Core Concept: Tool + Resource
+
+Every MCP App is built from two parts linked together:
+
+- **Tool** — called by the LLM or host. Returns a text/data response and tells the host which UI resource to render via `_meta.ui.resourceUri`.
+- **AppResource** — serves the self-contained HTML app. The host fetches it after the tool is called and renders it in a sandboxed iframe.
+
+```
+LLM calls Tool
+    └─► Tool response includes _meta.ui.resourceUri → "ui://dashboard-app"
+            └─► Host fetches AppResource at that URI
+                    └─► Host renders HTML in sandboxed iframe
+                            └─► createMcpApp() connects the iframe back to the server
+                                    └─► UI calls app-only tools to load/refresh data
+```
+
+The link is declared once with `#[RendersApp]` on the tool:
+
+```php
+#[RendersApp(resource: DashboardApp::class)]
+class ShowDashboard extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        return Response::text('Dashboard loaded.');
+    }
+}
+```
+
+After that, the host handles fetching and rendering the resource automatically — you never reference the URI by hand.
+
+---
+
+## Architecture Overview
+
+MCP Apps add interactive UI to the Model Context Protocol. The server returns self-contained HTML with all JS/CSS inlined. The host renders it in a sandboxed iframe. Apps communicate back via `createMcpApp()` — a pre-bundled global implementing the MCP UI PostMessage protocol.
+
+```
+┌─────────────────────────────────────────────┐
+│  Host (Claude, ChatGPT, VS Code)            │
+│  ┌───────────────────────────────────────┐  │
+│  │  Sandboxed iframe                     │  │
+│  │  ┌─────────────────────────────────┐  │  │
+│  │  │  Your MCP App (HTML/JS/CSS)     │  │  │
+│  │  │  - Rendered by AppResource       │  │  │
+│  │  │  - Single self-contained HTML   │  │  │
+│  │  │  - Themed via host CSS vars     │  │  │
+│  │  └─────────────────────────────────┘  │  │
+│  └───────────────────────────────────────┘  │
+└──────────────────┬──────────────────────────┘
+                   │ MCP Protocol (JSON-RPC)
+┌──────────────────▼──────────────────────────┐
+│  Laravel MCP Server                         │
+│  - AppResource → self-contained HTML         │
+│  - Tool #[RendersApp] → triggers UI display   │
+│  - resources/read → serves HTML + _meta.ui  │
+└─────────────────────────────────────────────┘
+```
+
+The server automatically advertises `io.modelcontextprotocol/ui` capability when any `AppResource` is registered. The client declares support in `capabilities.extensions["io.modelcontextprotocol/ui"]` during the initialize handshake.
+
+---
+
+## Server-Side
+
+Minimal case — `handle()` renders the Blade view, entire app lives there:
+
+```php
+class DashboardApp extends AppResource
+{
+    public function handle(Request $request): Response
+    {
+        return Response::view('mcp.dashboard-app', [
+            'title' => $this->title(),
+        ]);
+    }
+}
+```
+
+Auto-renders `resources/views/mcp/dashboard-app.blade.php` with `$title` available via `$this->title()`.
+
+Override `handle()` only when passing additional server-side data:
+
+```php
+class AnalyticsDashboard extends AppResource
+{
+    public function handle(Request $request): Response
+    {
+        return Response::view('mcp.analytics-dashboard', [
+            'title' => $this->title(),
+            'metrics' => Metric::latest()->take(10)->get(),
+            'totalUsers' => User::count(),
+        ]);
+    }
+}
+```
+
+`Response::view($view, $data = [], $mergeData = [])` renders a Blade view and returns it as text.
+
+`Response::html($path)` reads an HTML file from disk and returns its content. Relative paths resolve via `resource_path()`:
+
+```php
+class StaticApp extends AppResource
+{
+    public function handle(Request $request): Response
+    {
+        return Response::html('mcp/static-app.html');
+    }
+}
+```
+
+### AppMeta Configuration
+
+The simplest way to configure UI metadata is via the `#[AppMeta]` attribute directly on your resource class:
+
+```php
+use Laravel\Mcp\Server\Attributes\AppMeta;
+use Laravel\Mcp\Server\Ui\Enums\Library;
+use Laravel\Mcp\Server\Ui\Enums\Permission;
+
+#[AppMeta(
+    connectDomains: ['https://api.stripe.com'],
+    permissions: [Permission::Camera, Permission::ClipboardWrite],
+    prefersBorder: true,
+    libraries: [Library::Tailwind, Library::Alpine],
+)]
+class PaymentsResource extends AppResource
+{
+    // ...
+}
+```
+
+For dynamic or computed configuration, override `appMeta()` instead:
+
+```php
+use Laravel\Mcp\Server\Ui\AppMeta;
+
+public function appMeta(): AppMeta
+{
+    return AppMeta::make()
+        ->csp(Csp::make()->connectDomains(config('services.api.domains')))
+        ->permissions(Permissions::make()->allow(Permission::Camera))
+        ->libraries(Library::Tailwind)
+        ->domain('sandbox.example.com');
+}
+```
+
+#### Permission Enum
+
+Use the `Permission` enum for type-safe permission configuration:
+
+```php
+use Laravel\Mcp\Server\Ui\Enums\Permission;
+
+Permission::Camera        // 'camera'
+Permission::Microphone    // 'microphone'
+Permission::Geolocation   // 'geolocation'
+Permission::ClipboardWrite // 'clipboardWrite'
+```
+
+#### Csp
+
+Controls what external domains the iframe can access:
+
+```php
+Csp::make()
+    ->connectDomains(['https://api.example.com'])    // fetch, XHR, WebSocket origins
+    ->resourceDomains(['https://cdn.example.com'])   // images, scripts, fonts, media
+    ->frameDomains(['https://embed.example.com'])    // nested iframe origins
+    ->baseUriDomains(['https://base.example.com']);  // base URI origins
+```
+
+#### Permissions
+
+```php
+Permissions::make()->allow(Permission::Camera, Permission::ClipboardWrite);
+
+Permissions::make()
+    ->camera()
+    ->microphone()
+    ->geolocation()
+    ->clipboardWrite();
+```
+
+Each enabled permission serializes as `"camera": {}` per the MCP spec.
+
+#### AppMeta
+
+```php
+AppMeta::make()
+    ->csp(Csp::make()->connectDomains([...]))
+    ->permissions(Permissions::make()->allow(Permission::Camera))
+    ->libraries(Library::Tailwind, Library::Alpine)
+    ->domain('sandbox.example.com')  // dedicated sandbox origin (OAuth/CORS)
+    ->prefersBorder(false);
+```
+
+`prefersBorder` defaults to `true`. `toArray()` omits null fields and empty nested objects. Library CDN domains are automatically merged into `csp.resourceDomains`.
+
+#### domain
+
+The `domain` field provides a stable origin that external APIs can allowlist for CORS. It is automatically resolved from `config('app.url')` (your `APP_URL` env variable) via `resolvedAppMeta()`, so most apps need no configuration. Override only when a resource needs a different origin:
+
+```php
+#[AppMeta(domain: 'custom.example.com')]
+class PaymentsResource extends AppResource
+{
+    // ...
+}
+```
+
+#### Library Scripts
+
+The `libraries` parameter adds pre-configured CDN scripts to the `<head>` of your app. Available libraries:
+
+```php
+use Laravel\Mcp\Server\Ui\Enums\Library;
+
+Library::Tailwind  // Tailwind CSS CDN + dark mode config
+Library::Alpine    // Alpine.js CDN + x-cloak style
+```
+
+When libraries are specified, the package automatically:
+
+1. Injects the CDN `<script>` tags into the Blade view's `<head>` (after the MCP SDK, before your `<x-slot:head>`)
+2. Merges each library's CDN domains into `csp.resourceDomains` so the host allows loading them
+
+Via attribute:
+
+```php
+#[AppMeta(libraries: [Library::Tailwind])]
+class StyledApp extends AppResource
+{
+    // Tailwind is available in the Blade view — no extra setup
+}
+```
+
+Via fluent builder:
+
+```php
+public function appMeta(): AppMeta
+{
+    return AppMeta::make()
+        ->libraries(Library::Tailwind, Library::Alpine);
+}
+```
+
+---
+
+## View Layer
+
+### `<x-mcp::app>` Blade Component
+
+Renders a complete self-contained HTML document with the MCP SDK inlined. `createMcpApp` is available globally.
+
+```blade
+<x-mcp::app title="Dashboard App">
+    <x-slot:head>
+        <script type="module">
+        createMcpApp(async (app) => {
+            document.getElementById('run-btn').addEventListener('click', async () => {
+                const result = await app.callServerTool({ name: 'tool-name', arguments: {} });
+                document.getElementById('output').textContent = result.content[0]?.text ?? '';
+            });
+        });
+        </script>
+    </x-slot:head>
+
+    <div id="app">
+        <button id="run-btn">Run</button>
+        <p id="output"></p>
+    </div>
+</x-mcp::app>
+```
+
+**Props and slots:**
+
+| Name          | Type          | Description                                          |
+| ------------- | ------------- | ---------------------------------------------------- |
+| `title`       | Prop          | Sets `<title>`. Optional.                            |
+| `head`        | Named slot    | Injected into `<head>` after the inlined SDK script. |
+| Default slot  | Slot          | Body content.                                        |
+| `$attributes` | Attribute bag | Forwarded to `<body>` (e.g. `class="dark"`).         |
+
+The SDK is loaded from the `mcp.sdk` singleton (registered by `McpServiceProvider`) and inlined directly in a `<script>` tag. Library scripts (Tailwind, Alpine) configured via `#[AppMeta]` are injected after the SDK and before the `head` slot.
+
+Publish the component: `php artisan vendor:publish --tag=mcp-views`.
+
+To pass server-side data to JS, embed it as `data-*` attributes:
+
+```blade
+<div id="app" data-users="{{ $users->toJson() }}">
+    ...
+</div>
+```
+
+```js
+const users = JSON.parse(document.getElementById("app").dataset.users);
+```
+
+## Client-Side
+
+This package provides a simple MCP client library to easily work with client interactions.
+
+### createMcpApp
+
+Pre-bundled and inlined automatically — no npm install or imports required.
+
+```js
+createMcpApp(async (app) => {
+    // app is ready — connection established, theming applied
+});
+```
+
+### Tools
+
+#### app.callServerTool()
+
+Accepts an object or positional arguments:
+
+```js
+// Object form
+const result = await app.callServerTool({ name: 'get-analytics', arguments: { dateRange: '7d' } });
+
+// Positional form
+const result = await app.callServerTool('get-analytics', { dateRange: '7d' });
+
+// result structure depends on the server's tool response
+const text = result.content[0]?.text ?? "";
+```
+
+All tool results share a standard structure:
+
+| Property  | Type      | Description                                                               |
+| --------- | --------- | ------------------------------------------------------------------------- |
+| `content` | `Array`   | Content items returned by the tool (each has `type` and `text` or `data`) |
+| `isError` | `boolean` | `true` when the tool returned an error response                           |
+
+Always check `result.isError` before consuming `content`. See [Error Handling](#error-handling) for a full example.
+
+### Resources
+
+#### app.listResources()
+
+```js
+const resources = await app.listResources();
+// or with cursor for pagination
+const resources = await app.listResources("cursor-value");
+// or object form
+const resources = await app.listResources({ cursor: "cursor-value" });
+```
+
+#### app.readResource()
+
+```js
+const resource = await app.readResource("ui://my-resource");
+// or object form
+const resource = await app.readResource({ uri: "ui://my-resource" });
+```
+
+### Messaging
+
+#### app.sendMessage()
+
+Send a message to the model (creates a conversation turn):
+
+```js
+// Object form with structured content
+await app.sendMessage({
+    role: "user",
+    content: [{ type: "text", text: "User submitted the form." }],
+});
+
+// Shorthand — plain string content with optional role (defaults to 'user')
+await app.sendMessage("User submitted the form.");
+await app.sendMessage("System event occurred.", "user");
+```
+
+### Host Context
+
+#### app.getHostContext()
+
+Returns the current host context, including theme and style variables:
+
+```js
+const ctx = app.getHostContext();
+ctx?.theme; // 'light' | 'dark'
+ctx?.styles?.variables; // CSS variable map from host
+ctx?.styles?.css?.fonts; // font CSS from host
+```
+
+#### app.getHostInfo()
+
+```js
+const info = app.getHostInfo();
+```
+
+#### app.getHostCapabilities()
+
+```js
+const caps = app.getHostCapabilities();
+```
+
+### Navigation & Files
+
+#### app.openLink()
+
+```js
+await app.openLink("https://example.com");
+// or object form
+await app.openLink({ url: "https://example.com" });
+```
+
+#### app.downloadFile()
+
+```js
+await app.downloadFile("file contents here");
+// or object form
+await app.downloadFile({ contents: "file contents here" });
+```
+
+### Display
+
+#### app.requestDisplayMode()
+
+```js
+await app.requestDisplayMode("fullscreen");
+// or object form
+await app.requestDisplayMode({ mode: "fullscreen" });
+```
+
+#### app.resize() / app.autoResize()
+
+`resize()` sends a one-time size notification. `autoResize()` uses `ResizeObserver` to continuously notify the host of size changes. It returns a cleanup function that disconnects the observer — useful if you need to stop observing before teardown. The observer is also automatically disconnected on teardown.
+
+```js
+const stopObserving = app.autoResize();
+
+// Later, if needed:
+stopObserving();
+```
+
+### Model Context
+
+#### app.updateModelContext()
+
+```js
+await app.updateModelContext({ key: "value" });
+```
+
+### Lifecycle
+
+#### app.requestTeardown()
+
+Sends a teardown notification to the host.
+
+```js
+app.requestTeardown();
+```
+
+### Logging
+
+#### app.sendLog()
+
+```js
+// Positional form
+await app.sendLog("info", "Processing started", "my-logger");
+
+// Object form
+await app.sendLog({
+    level: "info",
+    data: "Processing started",
+    logger: "my-logger",
+});
+```
+
+### Event Handlers
+
+Register callbacks for host-side events. Tool input/result/cancelled events are queued until a handler is registered, then flushed.
+
+```js
+createMcpApp(async (app) => {
+    app.onToolInput((params) => {
+        /* tool input received */
+    });
+    app.onToolInputPartial((params) => {
+        /* partial tool input */
+    });
+    app.onToolResult((params) => {
+        /* tool result received */
+    });
+    app.onToolCancelled((params) => {
+        /* tool was cancelled */
+    });
+    app.onHostContextChanged((ctx) => {
+        /* theme/styles changed */
+    });
+    app.onTeardown(async () => {
+        /* cleanup before teardown */
+    });
+    app.onCallTool(async (params) => {
+        /* host requests tool call */
+    });
+    app.onListTools(async (params) => {
+        /* host requests tool list */
+    });
+});
+```
+
+---
+
+## Host Theming
+
+`createMcpApp` automatically applies host theming on connect and on context change:
+
+- Sets `data-theme` attribute and `color-scheme` on `<html>`
+- Applies CSS variables from `hostContext.styles.variables` to `:root`
+- Injects font CSS from `hostContext.styles.css.fonts` into a `<style>` tag
+
+The specific CSS variables available depend on the host. Always provide fallback values — use `light-dark()` for theme-aware defaults:
+
+```css
+:root {
+    --color-background-primary: light-dark(#ffffff, #171717);
+    --color-text-primary: light-dark(#171717, #fafafa);
+    --color-text-secondary: light-dark(#525252, #a3a3a3);
+    --color-border-primary: light-dark(#e5e5e5, #404040);
+    --font-sans: system-ui, -apple-system, sans-serif;
+    --border-radius-md: 8px;
+}
+
+body {
+    font-family: var(--font-sans);
+    background: var(--color-background-primary);
+    color: var(--color-text-primary);
+    margin: 0;
+}
+
+.card {
+    background: var(--color-background-secondary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: var(--border-radius-md);
+    padding: 1rem;
+}
+```
+
+---
+
+## Tool-to-UI Linking
+
+### #[RendersApp] Attribute
+
+Associates a Tool with a UI Resource. When the tool is called, the host fetches and renders the linked resource.
+
+```php
+use Laravel\Mcp\Server\Attributes\RendersApp;
+use Laravel\Mcp\Server\Ui\Enums\Visibility;
+
+// Both model and app can call this tool (default)
+#[RendersApp(resource: DashboardApp::class)]
+class ShowDashboard extends Tool { ... }
+
+// Only the app can call this tool (private to the UI)
+#[RendersApp(resource: DashboardApp::class, visibility: [Visibility::App])]
+class RefreshDashboardData extends Tool { ... }
+```
+
+**Visibility:**
+
+The `Visibility` enum (`Laravel\Mcp\Server\Ui\Enums\Visibility`) has two cases: `Model` and `App`. The default is `[Visibility::Model, Visibility::App]`.
+
+| Visibility                             | Model | App | Use case                                               |
+| -------------------------------------- | ----- | --- | ------------------------------------------------------ |
+| `[Visibility::Model, Visibility::App]` | Yes   | Yes | Primary tools that trigger UI display                  |
+| `[Visibility::App]`                    | No    | Yes | Backend actions the UI calls (refresh, save, paginate) |
+| `[Visibility::Model]`                  | Yes   | No  | Model-only tools linked to a UI                        |
+
+### Primary + Private Pattern
+
+```php
+#[RendersApp(resource: DashboardApp::class)]
+class ShowDashboard extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        return Response::text('Dashboard loaded.');
+    }
+}
+
+#[RendersApp(resource: DashboardApp::class, visibility: [Visibility::App])]
+class GetDashboardMetrics extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        return Response::json(Metric::latest()->take(50)->get());
+    }
+}
+```
+
+---
+
+## Testing
+
+```php
+it('returns html content', function () {
+    MyServer::readResource(DashboardApp::class)
+        ->assertSee('<div id="app">');
+});
+
+it('has correct mime type and uri scheme', function () {
+    $resource = new DashboardApp;
+    $data = $resource->toArray();
+
+    expect($data['mimeType'])->toBe('text/html;profile=mcp-app')
+        ->and($data['_meta']['ui'])->toBeArray()
+        ->and($resource->uri())->toStartWith('ui://');
+});
+
+it('configures ui meta correctly', function () {
+    $meta = (new DashboardApp)->resolvedAppMeta();
+
+    expect($meta['csp']['connectDomains'])->toContain('https://api.example.com')
+        ->and($meta['permissions'])->toHaveKey('clipboardWrite');
+});
+
+it('includes ui metadata in tool listing', function () {
+    MyServer::listTools()->assertSee('show-dashboard');
+});
+```
+
+---
+
+## Patterns
+
+### Real-time Polling
+
+Use app-only tools to fetch fresh data at regular intervals from the UI:
+
+```php
+#[RendersApp(resource: MonitorApp::class, visibility: [Visibility::App])]
+class GetMonitorData extends Tool
+{
+    protected string $description = 'Fetch latest monitor metrics';
+
+    public function handle(Request $request): Response
+    {
+        return Response::json([
+            'cpu' => sys_getloadavg()[0],
+            'memory' => memory_get_usage(true),
+            'timestamp' => now()->toISOString(),
+        ]);
+    }
+}
+```
+
+```js
+createMcpApp(async (app) => {
+    async function poll() {
+        const result = await app.callServerTool('get-monitor-data');
+        const data = JSON.parse(result.content[0]?.text ?? '{}');
+        document.getElementById('cpu').textContent = data.cpu;
+    }
+
+    setInterval(poll, 2000);
+    poll();
+});
+```
+
+### Chunked Data Loading
+
+For large datasets, implement pagination via app-only tools:
+
+```php
+#[RendersApp(resource: LogViewerApp::class, visibility: [Visibility::App])]
+class GetLogChunk extends Tool
+{
+    protected string $description = 'Fetch a chunk of log entries';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'offset' => $schema->integer()->description('Byte offset to start from')->required(),
+            'limit' => $schema->integer()->description('Max bytes to return'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $request->validate(['offset' => 'required|integer', 'limit' => 'integer']);
+
+        $offset = $request->get('offset');
+        $limit = $request->get('limit', 500_000);
+        $content = Storage::get('logs/app.log');
+        $chunk = substr($content, $offset, $limit);
+
+        return Response::json([
+            'data' => $chunk,
+            'offset' => $offset,
+            'totalBytes' => strlen($content),
+            'hasMore' => ($offset + $limit) < strlen($content),
+        ]);
+    }
+}
+```
+
+### Binary Resource Serving
+
+Deliver images and binary content through MCP resources using `Response::blob()`:
+
+```php
+#[RendersApp(resource: GalleryApp::class, visibility: [Visibility::App])]
+class GetImage extends Tool
+{
+    protected string $description = 'Fetch an image by ID';
+
+    public function handle(Request $request): Response
+    {
+        $request->validate(['id' => 'required|integer']);
+
+        $image = Image::findOrFail($request->get('id'));
+        $data = base64_encode(Storage::get($image->path));
+
+        return Response::blob($data);
+    }
+}
+```
+
+In the client, convert the base64 blob to a data URI for rendering:
+
+```js
+const result = await app.callServerTool('get-image', { id: 42 });
+const blob = result.content[0];
+img.src = `data:${blob.mimeType};base64,${blob.data}`;
+```
+
+### Streaming Argument Previews
+
+Use `onToolInputPartial` to show previews as the model streams tool arguments:
+
+```js
+createMcpApp(async (app) => {
+    app.onToolInputPartial((params) => {
+        try {
+            const partial = JSON.parse(params.arguments);
+            if (partial.query) {
+                document.getElementById("preview").textContent = partial.query;
+            }
+        } catch {
+            // partial JSON — ignore until parseable
+        }
+    });
+
+    app.onToolResult((params) => {
+        const data = JSON.parse(params.result.content[0]?.text ?? "{}");
+        renderResults(data);
+    });
+});
+```
+
+### View State Persistence
+
+Use `localStorage` to preserve UI state across re-renders. For important state, persist server-side via an app-only tool:
+
+```js
+createMcpApp(async (app) => {
+    const STATE_KEY = "dashboard-view-state";
+
+    // Restore from localStorage
+    const saved = JSON.parse(localStorage.getItem(STATE_KEY) || "{}");
+    if (saved.activeTab) selectTab(saved.activeTab);
+
+    // Save on interaction
+    function saveState(state) {
+        localStorage.setItem(STATE_KEY, JSON.stringify(state));
+    }
+
+    // For durable state, persist server-side
+    async function saveServerState(state) {
+        await app.callServerTool('save-dashboard-state', { state: JSON.stringify(state) });
+    }
+});
+```
+
+### Fullscreen Toggling
+
+Switch between inline and fullscreen display modes and react to mode changes:
+
+```js
+createMcpApp(async (app) => {
+    document.getElementById("expand-btn").addEventListener("click", () => {
+        app.requestDisplayMode("fullscreen");
+    });
+
+    app.onHostContextChanged((ctx) => {
+        document.body.classList.toggle(
+            "fullscreen",
+            ctx.displayMode === "fullscreen",
+        );
+    });
+});
+```
+
+### Model Context Updates
+
+Keep the model informed about what the user is viewing so it can provide relevant assistance:
+
+```js
+createMcpApp(async (app) => {
+    async function notifyContext(view, detail) {
+        await app.updateModelContext({
+            currentView: view,
+            detail: detail,
+        });
+    }
+
+    // Notify on tab change
+    document.querySelectorAll(".tab").forEach((tab) => {
+        tab.addEventListener("click", () => {
+            notifyContext(tab.dataset.view, { filters: getActiveFilters() });
+        });
+    });
+
+    // For large payloads, follow up with sendMessage
+    await app.updateModelContext({ currentView: "report", rows: 5000 });
+    await app.sendMessage("The user is viewing a report with 5000 rows.");
+});
+```
+
+### Pause Offscreen Views
+
+Conserve resources by pausing animations and polling when the view is not visible:
+
+```js
+createMcpApp(async (app) => {
+    let pollInterval = null;
+
+    function startPolling() {
+        if (!pollInterval) {
+            pollInterval = setInterval(fetchData, 2000);
+        }
+    }
+
+    function stopPolling() {
+        clearInterval(pollInterval);
+        pollInterval = null;
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+        entry.isIntersecting ? startPolling() : stopPolling();
+    });
+
+    observer.observe(document.documentElement);
+    startPolling();
+});
+```
+
+### Error Handling
+
+Return `Response::error()` from tools and use `updateModelContext()` to signal degraded state:
+
+```php
+class ProcessData extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        $request->validate(['input' => 'required|string']);
+
+        if (strlen($request->get('input')) > 10_000) {
+            return Response::error('Input exceeds 10KB limit.');
+        }
+
+        return Response::json(process($request->get('input')));
+    }
+}
+```
+
+```js
+createMcpApp(async (app) => {
+    const result = await app.callServerTool('process-data', { input: value });
+
+    if (result.isError) {
+        document.getElementById("error").textContent =
+            result.content[0]?.text ?? "Unknown error";
+        await app.updateModelContext({
+            state: "error",
+            message: result.content[0]?.text,
+        });
+        return;
+    }
+
+    renderOutput(JSON.parse(result.content[0]?.text ?? "{}"));
+});
+```

--- a/.claude/skills/passport-development/SKILL.md
+++ b/.claude/skills/passport-development/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: passport-development
+description: "Develops OAuth2 API authentication with Laravel Passport. Activates when installing or configuring Passport; setting up OAuth2 grants (authorization code, client credentials, personal access tokens, device authorization); managing OAuth clients; protecting API routes with token authentication; defining or checking token scopes; configuring SPA cookie authentication; handling token lifetimes and refresh tokens; or when the user mentions Passport, OAuth2, API tokens, bearer tokens, or API authentication. Make sure to use this skill whenever the user works with OAuth2, API tokens, or third-party API access, even if they don't explicitly mention Passport."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Passport OAuth2 Authentication
+
+## Documentation First
+
+**Always use `search-docs` before writing Passport code.** The documentation covers every grant type, configuration option, and edge case in detail. This skill teaches you how to navigate Passport — the docs have the implementation specifics.
+
+```
+search-docs(queries: ["Passport installation"], packages: ["laravel/framework@12.x"])
+```
+
+The Passport docs live under the `laravel/framework` package — not `laravel/passport`.
+
+## When to Apply
+
+Activate this skill when:
+
+- Installing or configuring Passport
+- Setting up OAuth2 authorization grants
+- Creating or managing OAuth clients
+- Protecting API routes with token authentication
+- Defining or checking token scopes
+- Configuring SPA cookie-based authentication
+- Choosing between Passport and Sanctum
+
+## Passport vs. Sanctum
+
+**Passport** is a full OAuth2 server — use it when third-party applications need to consume your API and when you need OAuth2 authorization code grants, client credentials for machine-to-machine auth, or device authorization flow.
+
+**Sanctum** is simpler — use it when first-party SPAs, third parties, or mobile apps consume the API but you don't need the full OAuth2 grant flows.
+
+## Installation
+
+Three steps are always required:
+
+### 1. Install Passport
+
+```bash
+php artisan install:api --passport
+```
+
+This publishes migrations, generates encryption keys, and registers routes.
+
+### 2. Configure the User model
+
+The User model needs both the `HasApiTokens` trait AND the `OAuthenticatable` interface. Missing the interface is the most common Passport setup mistake — it causes runtime errors that can be confusing to debug.
+
+```php
+use Laravel\Passport\Contracts\OAuthenticatable;
+use Laravel\Passport\HasApiTokens;
+
+class User extends Authenticatable implements OAuthenticatable
+{
+    use HasApiTokens;
+}
+```
+
+### 3. Configure the auth guard
+
+The `api` guard must use the `passport` driver in `config/auth.php`. Using `token` or `sanctum` here silently breaks Passport authentication.
+
+```php
+'guards' => [
+    'api' => [
+        'driver' => 'passport',
+        'provider' => 'users',
+    ],
+],
+```
+
+## Choosing a Grant Type
+
+Matching the right grant to the use case is the most important Passport decision. Use `search-docs` for implementation details of any grant.
+
+| Use Case | Grant Type | Client Flag |
+|----------|-----------|-------------|
+| Third-party app accessing user data | Authorization Code | (default) |
+| Mobile/SPA without client secret | Authorization Code + PKCE | `--public` |
+| Machine-to-machine, no user context | Client Credentials | `--client` |
+| User-generated API keys | Personal Access Tokens | `--personal` |
+| Smart TV, CLI, IoT devices | Device Authorization | `--device` |
+
+**Legacy grants** (Password, Implicit) are disabled by default and not recommended. They must be explicitly enabled with `Passport::enablePasswordGrant()` or `Passport::enableImplicitGrant()`.
+
+## Client Management
+
+Create clients with the appropriate flag for the grant type:
+
+```bash
+php artisan passport:client              # Authorization code
+
+php artisan passport:client --public     # PKCE (no secret)
+
+php artisan passport:client --client     # Client credentials
+
+php artisan passport:client --personal   # Personal access tokens
+
+php artisan passport:client --device     # Device authorization
+
+```
+
+Additional flags: `--name=`, `--redirect_uri=`, `--provider=`.
+
+Client secrets are hashed by default — the plain-text secret is only shown at creation time and cannot be retrieved later.
+
+## Protecting Routes
+
+Apply `auth:api` middleware. Clients send tokens via the `Authorization: Bearer <token>` header.
+
+```php
+Route::get('/user', function (Request $request) {
+    return $request->user();
+})->middleware('auth:api');
+```
+
+### Scope Enforcement
+
+Scope middleware must come alongside `auth:api`:
+
+- `CheckToken::using('scope1', 'scope2')` — requires ALL listed scopes
+- `CheckTokenForAnyScope::using('scope1', 'scope2')` — requires ANY listed scope
+- `EnsureClientIsResourceOwner::using('scope1')` — restricts to client credential tokens
+
+```php
+use Laravel\Passport\Http\Middleware\CheckToken;
+
+Route::get('/orders', function () {
+    // ...
+})->middleware(['auth:api', CheckToken::using('orders:read')]);
+```
+
+### Programmatic scope checking
+
+```php
+if ($request->user()->tokenCan('place-orders')) {
+    // ...
+}
+```
+
+Use `search-docs` for full scope middleware registration and usage patterns.
+
+## Key Configuration
+
+Configure in `AppServiceProvider::boot()`. Use `search-docs` for the full list of options.
+
+```php
+// Token lifetimes (each is independent)
+Passport::tokensExpireIn(now()->addDays(15));
+Passport::refreshTokensExpireIn(now()->addDays(30));
+Passport::personalAccessTokensExpireIn(now()->addMonths(6));
+
+// Define scopes
+Passport::tokensCan([
+    'place-orders' => 'Place orders',
+    'check-status' => 'Check order status',
+]);
+```
+
+## SPA Cookie Authentication
+
+For first-party SPAs, the `CreateFreshApiToken` middleware issues a `laravel_token` cookie containing an encrypted JWT. The SPA must include CSRF tokens — missing the `X-CSRF-TOKEN` or `X-XSRF-TOKEN` header causes 419 errors.
+
+Use `search-docs` for setup details — this feature has specific CSRF and cookie configuration requirements.
+
+## Testing
+
+Passport provides helpers to bypass full OAuth flows in tests:
+
+```php
+Passport::actingAs($user, ['scope1', 'scope2']);
+Passport::actingAsClient($client, ['scope1']);
+```
+
+## Token Maintenance
+
+```bash
+php artisan passport:purge              # Purge revoked & expired
+
+php artisan passport:purge --revoked    # Only revoked
+
+php artisan passport:purge --expired    # Only expired
+
+```
+
+Schedule `passport:purge` for regular expired token clean-up.
+
+## Events
+
+All in `Laravel\Passport\Events`: `AccessTokenCreated`, `AccessTokenRevoked`, `RefreshTokenCreated`.
+
+## Common Pitfalls
+
+- **Missing `OAuthenticatable` interface** — both the `HasApiTokens` trait and the `OAuthenticatable` interface are required on the User model. Missing the interface causes runtime errors.
+- **Wrong guard driver** — the `api` guard must use `passport`, not `token` or `sanctum`. This fails silently.
+- **Token lifetime confusion** — access token, refresh token, and personal access token lifetimes are all independent settings.
+- **Missing CSRF for SPA cookie auth** — `CreateFreshApiToken` requires CSRF tokens. Use `Passport::ignoreCsrfToken()` only if you understand the security implications.
+- **Client secrets are hashed** — the plain-text secret is only available at creation time.
+- **Legacy grants are disabled** — Password and Implicit grants must be explicitly enabled and are not recommended.

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log
 /.zed
 /.superpowers
 /.worktrees
+/.mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - laravel/framework (LARAVEL) - v13
 - laravel/mcp (MCP) - v0
 - laravel/prompts (PROMPTS) - v0
+- laravel/sanctum (SANCTUM) - v4
 - laravel/wayfinder (WAYFINDER) - v0
 - larastan/larastan (LARASTAN) - v3
 - laravel/boost (BOOST) - v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - laravel/fortify (FORTIFY) - v1
 - laravel/framework (LARAVEL) - v13
 - laravel/mcp (MCP) - v0
+- laravel/passport (PASSPORT) - v13
 - laravel/prompts (PROMPTS) - v0
 - laravel/sanctum (SANCTUM) - v4
 - laravel/wayfinder (WAYFINDER) - v0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,11 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - inertiajs/inertia-laravel (INERTIA_LARAVEL) - v3
 - laravel/fortify (FORTIFY) - v1
 - laravel/framework (LARAVEL) - v13
+- laravel/mcp (MCP) - v0
 - laravel/prompts (PROMPTS) - v0
 - laravel/wayfinder (WAYFINDER) - v0
 - larastan/larastan (LARASTAN) - v3
 - laravel/boost (BOOST) - v2
-- laravel/mcp (MCP) - v0
 - laravel/pail (PAIL) - v1
 - laravel/pint (PINT) - v1
 - laravel/sail (SAIL) - v1

--- a/README.md
+++ b/README.md
@@ -159,6 +159,48 @@ real `APP_KEY` or other production secrets that can't be stripped.**
 runtime, so a desktop release must be built from its own freshly generated
 key, not a copy of the production web `.env`.
 
+## MCP server (AI agent integration)
+
+Biglins ships an [MCP](https://modelcontextprotocol.io/) server so AI agents (Claude, etc.) can list/create customers, list/create estimations, list/create invoices, and send an invoice or estimation by email — see `app/Mcp/Servers/BiglinsServer.php` and `app/Mcp/Tools/` for the 8 tools. Every tool takes an explicit `company_id` (there's no per-user tenancy in this app: any authenticated user/token can act on any company in the database). Registered in [routes/ai.php](routes/ai.php), with two transports depending on how you run Biglins:
+
+### Desktop app (local, no auth)
+
+The desktop build runs single-user on your own machine, so the local transport needs no token — whoever can run the command already has full access to your local database. Point your MCP client at:
+
+```json
+{
+  "mcpServers": {
+    "biglins": {
+      "command": "php",
+      "args": ["artisan", "mcp:start", "biglins"],
+      "cwd": "/path/to/biglins"
+    }
+  }
+}
+```
+
+### Docker / web deployment (HTTP + API token)
+
+An HTTP endpoint is exposed at `/mcp/biglins`, protected by a [Sanctum](https://laravel.com/docs/sanctum) personal access token — required since a Docker deployment can be reachable over the internet.
+
+1. Log in, go to **Settings → API Tokens**, and create a token (the value is shown once — copy it immediately, only its hash is stored).
+2. Point your MCP client at the endpoint with that token as a bearer token:
+
+```json
+{
+  "mcpServers": {
+    "biglins": {
+      "url": "https://your-domain.example/mcp/biglins",
+      "headers": {
+        "Authorization": "Bearer <your-api-token>"
+      }
+    }
+  }
+}
+```
+
+Revoke a token any time from the same Settings page — revocation is immediate.
+
 ## Useful commands
 
 | Command                           | Description                                    |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Invoicing app for freelancers and sole proprietors: customer records, invoices w
 
 ## Stack
 
-- **Backend**: Laravel 13 (PHP 8.3+), Inertia.js v3, Laravel Fortify (auth, 2FA, passkeys)
+- **Backend**: Laravel 13 (PHP 8.3+), Inertia.js v3, Laravel Fortify (auth, 2FA, passkeys), Laravel Sanctum + Passport (API tokens / MCP OAuth)
 - **Frontend**: Vue 3 + TypeScript, Inertia Vue, Tailwind CSS v4, reka-ui
 - **Typed routing**: Laravel Wayfinder (`resources/js/actions`, `resources/js/routes`, generated — not versioned)
 - **PDF**: barryvdh/laravel-dompdf
@@ -200,6 +200,24 @@ An HTTP endpoint is exposed at `/mcp/biglins`, protected by a [Sanctum](https://
 ```
 
 Revoke a token any time from the same Settings page — revocation is immediate.
+
+### Claude Desktop (OAuth)
+
+The bearer-token setup above works for clients that let you set custom
+headers (e.g. Claude Code), but Claude Desktop's built-in "Add custom
+connector" dialog only supports OAuth — it doesn't have a field for a raw
+token. For that client, point it at the HTTP endpoint instead:
+
+1. In Claude Desktop, add a custom connector with URL `https://your-domain.example/mcp/biglins`.
+2. Leave the OAuth Client ID/Secret fields blank — Claude registers its own client automatically via [dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591).
+3. Claude opens a browser to log in and approve access; tokens are then managed by Claude, no manual copying needed.
+
+This is backed by [Laravel Passport](https://laravel.com/docs/passport) as the
+OAuth2 authorization server (`laravel/passport`), configured alongside
+Sanctum — the `/mcp/biglins` endpoint accepts either a Sanctum API token or a
+Passport OAuth token. Manage authorized OAuth clients like any other Passport
+installation (`php artisan passport:client --list`, `passport:purge` for
+expired/revoked tokens).
 
 ## Useful commands
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ cp .env.example .env
 php artisan key:generate
 touch database/database.sqlite
 php artisan migrate
+php artisan passport:keys
 npm run build   # or npm run dev in another terminal
 ```
 

--- a/app/Http/Controllers/Settings/ApiTokenController.php
+++ b/app/Http/Controllers/Settings/ApiTokenController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\StoreApiTokenRequest;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class ApiTokenController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('settings/ApiTokens', [
+            'tokens' => request()->user()
+                ->tokens()
+                ->select(['id', 'name', 'created_at', 'last_used_at'])
+                ->latest()
+                ->get()
+                ->map(fn (PersonalAccessToken $token): array => [
+                    'id' => $token->id,
+                    'name' => $token->name,
+                    'created_at_diff' => $token->created_at?->diffForHumans(),
+                    'last_used_at_diff' => $token->last_used_at?->diffForHumans(),
+                ])
+                ->values()
+                ->all(),
+        ]);
+    }
+
+    public function store(StoreApiTokenRequest $request): RedirectResponse
+    {
+        $token = $request->user()->createToken($request->validated('name'));
+
+        Inertia::flash('newApiToken', $token->plainTextToken);
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('API token created.')]);
+
+        return to_route('api-tokens.index');
+    }
+
+    public function destroy(int $token): RedirectResponse
+    {
+        $accessToken = PersonalAccessToken::query()->findOrFail($token);
+
+        abort_unless($accessToken->tokenable_id === request()->user()->id, 403);
+
+        $accessToken->delete();
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('API token revoked.')]);
+
+        return to_route('api-tokens.index');
+    }
+}

--- a/app/Http/Requests/Settings/StoreApiTokenRequest.php
+++ b/app/Http/Requests/Settings/StoreApiTokenRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreApiTokenRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Mcp/Servers/BiglinsServer.php
+++ b/app/Mcp/Servers/BiglinsServer.php
@@ -3,6 +3,7 @@
 namespace App\Mcp\Servers;
 
 use App\Mcp\Tools\CreateCustomerTool;
+use App\Mcp\Tools\CreateEstimationTool;
 use App\Mcp\Tools\ListCustomersTool;
 use App\Mcp\Tools\ListEstimationsTool;
 use Laravel\Mcp\Server;
@@ -19,5 +20,6 @@ class BiglinsServer extends Server
         ListCustomersTool::class,
         CreateCustomerTool::class,
         ListEstimationsTool::class,
+        CreateEstimationTool::class,
     ];
 }

--- a/app/Mcp/Servers/BiglinsServer.php
+++ b/app/Mcp/Servers/BiglinsServer.php
@@ -6,6 +6,7 @@ use App\Mcp\Tools\CreateCustomerTool;
 use App\Mcp\Tools\CreateEstimationTool;
 use App\Mcp\Tools\ListCustomersTool;
 use App\Mcp\Tools\ListEstimationsTool;
+use App\Mcp\Tools\ListInvoicesTool;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Attributes\Instructions;
 use Laravel\Mcp\Server\Attributes\Name;
@@ -21,5 +22,6 @@ class BiglinsServer extends Server
         CreateCustomerTool::class,
         ListEstimationsTool::class,
         CreateEstimationTool::class,
+        ListInvoicesTool::class,
     ];
 }

--- a/app/Mcp/Servers/BiglinsServer.php
+++ b/app/Mcp/Servers/BiglinsServer.php
@@ -4,6 +4,7 @@ namespace App\Mcp\Servers;
 
 use App\Mcp\Tools\CreateCustomerTool;
 use App\Mcp\Tools\CreateEstimationTool;
+use App\Mcp\Tools\CreateInvoiceTool;
 use App\Mcp\Tools\ListCustomersTool;
 use App\Mcp\Tools\ListEstimationsTool;
 use App\Mcp\Tools\ListInvoicesTool;
@@ -23,5 +24,6 @@ class BiglinsServer extends Server
         ListEstimationsTool::class,
         CreateEstimationTool::class,
         ListInvoicesTool::class,
+        CreateInvoiceTool::class,
     ];
 }

--- a/app/Mcp/Servers/BiglinsServer.php
+++ b/app/Mcp/Servers/BiglinsServer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Mcp\Servers;
+
+use App\Mcp\Tools\ListCustomersTool;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
+
+#[Name('Biglins')]
+#[Version('1.0.0')]
+#[Instructions('Manage customers, estimations, and invoices for a Biglins company, and send them by email. Every tool takes an explicit company_id — use list_customers/list_estimations/list_invoices to discover existing records before creating new ones.')]
+class BiglinsServer extends Server
+{
+    protected array $tools = [
+        ListCustomersTool::class,
+    ];
+}

--- a/app/Mcp/Servers/BiglinsServer.php
+++ b/app/Mcp/Servers/BiglinsServer.php
@@ -8,6 +8,7 @@ use App\Mcp\Tools\CreateInvoiceTool;
 use App\Mcp\Tools\ListCustomersTool;
 use App\Mcp\Tools\ListEstimationsTool;
 use App\Mcp\Tools\ListInvoicesTool;
+use App\Mcp\Tools\SendEstimationEmailTool;
 use App\Mcp\Tools\SendInvoiceEmailTool;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Attributes\Instructions;
@@ -26,6 +27,7 @@ class BiglinsServer extends Server
         CreateEstimationTool::class,
         ListInvoicesTool::class,
         CreateInvoiceTool::class,
+        SendEstimationEmailTool::class,
         SendInvoiceEmailTool::class,
     ];
 }

--- a/app/Mcp/Servers/BiglinsServer.php
+++ b/app/Mcp/Servers/BiglinsServer.php
@@ -4,6 +4,7 @@ namespace App\Mcp\Servers;
 
 use App\Mcp\Tools\CreateCustomerTool;
 use App\Mcp\Tools\ListCustomersTool;
+use App\Mcp\Tools\ListEstimationsTool;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Attributes\Instructions;
 use Laravel\Mcp\Server\Attributes\Name;
@@ -17,5 +18,6 @@ class BiglinsServer extends Server
     protected array $tools = [
         ListCustomersTool::class,
         CreateCustomerTool::class,
+        ListEstimationsTool::class,
     ];
 }

--- a/app/Mcp/Servers/BiglinsServer.php
+++ b/app/Mcp/Servers/BiglinsServer.php
@@ -8,6 +8,7 @@ use App\Mcp\Tools\CreateInvoiceTool;
 use App\Mcp\Tools\ListCustomersTool;
 use App\Mcp\Tools\ListEstimationsTool;
 use App\Mcp\Tools\ListInvoicesTool;
+use App\Mcp\Tools\SendInvoiceEmailTool;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Attributes\Instructions;
 use Laravel\Mcp\Server\Attributes\Name;
@@ -25,5 +26,6 @@ class BiglinsServer extends Server
         CreateEstimationTool::class,
         ListInvoicesTool::class,
         CreateInvoiceTool::class,
+        SendInvoiceEmailTool::class,
     ];
 }

--- a/app/Mcp/Servers/BiglinsServer.php
+++ b/app/Mcp/Servers/BiglinsServer.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Servers;
 
+use App\Mcp\Tools\CreateCustomerTool;
 use App\Mcp\Tools\ListCustomersTool;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Attributes\Instructions;
@@ -15,5 +16,6 @@ class BiglinsServer extends Server
 {
     protected array $tools = [
         ListCustomersTool::class,
+        CreateCustomerTool::class,
     ];
 }

--- a/app/Mcp/Tools/CreateCustomerTool.php
+++ b/app/Mcp/Tools/CreateCustomerTool.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Http\Requests\StoreCustomerRequest;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Support\CurrentCompany;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('create_customer')]
+#[Description('Create a new customer under a given company.')]
+class CreateCustomerTool extends Tool
+{
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        try {
+            $companyId = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+            ])['company_id'];
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $company = Company::query()->findOrFail($companyId);
+
+        return CurrentCompany::runningAs($company, function () use ($request, $company): Response|ResponseFactory {
+            try {
+                $data = $request->validate((new StoreCustomerRequest)->rules());
+            } catch (ValidationException $e) {
+                return Response::error($e->validator->errors()->first());
+            }
+
+            $customer = Customer::query()->create([
+                ...$data,
+                'company_id' => $company->id,
+            ]);
+
+            return Response::structured(['customer' => $customer->toArray()]);
+        });
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to create the customer under.')->required(),
+            'name' => $schema->string()->description('Customer name.')->required(),
+            'address' => $schema->string()->description('Street address.'),
+            'zip' => $schema->string()->description('Postal code.'),
+            'city' => $schema->string(),
+            'country_id' => $schema->string()->description('UUID of an existing country.'),
+            'state' => $schema->string()->description('State or province.'),
+            'email' => $schema->string()->format('email'),
+            'web' => $schema->string()->format('uri'),
+            'phone' => $schema->string(),
+            'nif' => $schema->string()->description('Tax identification number.'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/CreateCustomerTool.php
+++ b/app/Mcp/Tools/CreateCustomerTool.php
@@ -24,7 +24,7 @@ class CreateCustomerTool extends Tool
     public function handle(Request $request): Response|ResponseFactory
     {
         try {
-            $companyId = $request->validate([
+            $companyId = (string) $request->validate([
                 'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
             ])['company_id'];
         } catch (ValidationException $e) {

--- a/app/Mcp/Tools/CreateEstimationTool.php
+++ b/app/Mcp/Tools/CreateEstimationTool.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Http\Requests\StoreEstimationRequest;
+use App\Models\Company;
+use App\Models\Estimation;
+use App\Support\CurrentCompany;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('create_estimation')]
+#[Description('Create a new estimation with line items for an existing customer.')]
+class CreateEstimationTool extends Tool
+{
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        try {
+            $companyId = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+            ])['company_id'];
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $company = Company::query()->findOrFail($companyId);
+
+        return CurrentCompany::runningAs($company, function () use ($request, $company): Response|ResponseFactory {
+            try {
+                $data = $request->validate((new StoreEstimationRequest)->rules());
+            } catch (ValidationException $e) {
+                return Response::error($e->validator->errors()->first());
+            }
+
+            $estimation = DB::transaction(function () use ($data, $company): Estimation {
+                $estimation = Estimation::query()->create([
+                    ...collect($data)->except('rows')->all(),
+                    'company_id' => $company->id,
+                ]);
+
+                $estimation->rows()->createMany($data['rows']);
+
+                return $estimation;
+            });
+
+            return Response::structured(['estimation' => $estimation->load('rows')->toArray()]);
+        });
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to create the estimation under.')->required(),
+            'customer_id' => $schema->string()->description('UUID of an existing customer belonging to the company.')->required(),
+            'estimation_date' => $schema->string()->format('date')->description('YYYY-MM-DD.')->required(),
+            'expiration_date' => $schema->string()->format('date')->description('YYYY-MM-DD, must be on or after estimation_date.')->required(),
+            'language' => $schema->string()->enum(['it', 'en', 'es'])->required(),
+            'body' => $schema->string()->description('Optional markdown body/notes.'),
+            'rows' => $schema->array()->items(
+                $schema->object([
+                    'description' => $schema->string()->required(),
+                    'quantity' => $schema->number()->required(),
+                    'price' => $schema->number()->required(),
+                    'vat_rate' => $schema->number()->required(),
+                    'note' => $schema->string(),
+                ])
+            )->description('Line items, at least one required.')->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/CreateEstimationTool.php
+++ b/app/Mcp/Tools/CreateEstimationTool.php
@@ -25,7 +25,7 @@ class CreateEstimationTool extends Tool
     public function handle(Request $request): Response|ResponseFactory
     {
         try {
-            $companyId = $request->validate([
+            $companyId = (string) $request->validate([
                 'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
             ])['company_id'];
         } catch (ValidationException $e) {

--- a/app/Mcp/Tools/CreateInvoiceTool.php
+++ b/app/Mcp/Tools/CreateInvoiceTool.php
@@ -26,7 +26,7 @@ class CreateInvoiceTool extends Tool
     public function handle(Request $request): Response|ResponseFactory
     {
         try {
-            $companyId = $request->validate([
+            $companyId = (string) $request->validate([
                 'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
             ])['company_id'];
         } catch (ValidationException $e) {
@@ -49,13 +49,13 @@ class CreateInvoiceTool extends Tool
                 ]);
 
                 $type = $invoice->type;
-                $rows = collect($data['rows'])->map(function (array $row) use ($type): array {
+                $rows = array_map(function (array $row) use ($type): array {
                     if ($type === InvoiceType::CreditNote) {
                         $row['price'] = -abs((float) $row['price']);
                     }
 
                     return $row;
-                });
+                }, $data['rows']);
 
                 $invoice->rows()->createMany($rows);
 

--- a/app/Mcp/Tools/CreateInvoiceTool.php
+++ b/app/Mcp/Tools/CreateInvoiceTool.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Enums\InvoiceType;
+use App\Http\Requests\StoreInvoiceRequest;
+use App\Models\Company;
+use App\Models\Invoice;
+use App\Support\CurrentCompany;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('create_invoice')]
+#[Description('Create a new invoice (or credit note) with line items for an existing customer.')]
+class CreateInvoiceTool extends Tool
+{
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        try {
+            $companyId = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+            ])['company_id'];
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $company = Company::query()->findOrFail($companyId);
+
+        return CurrentCompany::runningAs($company, function () use ($request, $company): Response|ResponseFactory {
+            try {
+                $data = $request->validate((new StoreInvoiceRequest)->rules());
+            } catch (ValidationException $e) {
+                return Response::error($e->validator->errors()->first());
+            }
+
+            $invoice = DB::transaction(function () use ($data, $company): Invoice {
+                $invoice = Invoice::query()->create([
+                    ...collect($data)->except('rows')->all(),
+                    'company_id' => $company->id,
+                ]);
+
+                $type = $invoice->type;
+                $rows = collect($data['rows'])->map(function (array $row) use ($type): array {
+                    if ($type === InvoiceType::CreditNote) {
+                        $row['price'] = -abs((float) $row['price']);
+                    }
+
+                    return $row;
+                });
+
+                $invoice->rows()->createMany($rows);
+
+                return $invoice;
+            });
+
+            return Response::structured(['invoice' => $invoice->load('rows')->toArray()]);
+        });
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to create the invoice under.')->required(),
+            'customer_id' => $schema->string()->description('UUID of an existing customer belonging to the company.')->required(),
+            'type' => $schema->string()->enum(['invoice', 'credit_note'])->description('Defaults to invoice.'),
+            'invoice_date' => $schema->string()->format('date')->description('YYYY-MM-DD.')->required(),
+            'note' => $schema->string(),
+            'language' => $schema->string()->enum(['it', 'en', 'es'])->required(),
+            'rows' => $schema->array()->items(
+                $schema->object([
+                    'description' => $schema->string()->required(),
+                    'quantity' => $schema->number()->required(),
+                    'price' => $schema->number()->required(),
+                    'vat_rate' => $schema->number()->required(),
+                    'expiration_date' => $schema->string()->format('date'),
+                ])
+            )->description('Line items, at least one required.')->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/ListCustomersTool.php
+++ b/app/Mcp/Tools/ListCustomersTool.php
@@ -13,9 +13,11 @@ use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 
 #[Name('list_customers')]
 #[Description('List customers for a given company, optionally filtered by a search term matched against name or email.')]
+#[IsReadOnly]
 class ListCustomersTool extends Tool
 {
     public function handle(Request $request): Response|ResponseFactory

--- a/app/Mcp/Tools/ListCustomersTool.php
+++ b/app/Mcp/Tools/ListCustomersTool.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\Customer;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('list_customers')]
+#[Description('List customers for a given company, optionally filtered by a search term matched against name or email.')]
+class ListCustomersTool extends Tool
+{
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        try {
+            $data = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+                'search' => ['nullable', 'string'],
+            ]);
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $search = trim($data['search'] ?? '');
+
+        $customers = Customer::query()
+            ->where('company_id', $data['company_id'])
+            ->when($search !== '', fn ($query) => $query->where(function ($query) use ($search) {
+                $query->where('name', 'like', "%{$search}%")
+                    ->orWhere('email', 'like', "%{$search}%");
+            }))
+            ->orderBy('name')
+            ->limit(50)
+            ->get(['id', 'name', 'email', 'city', 'country_id']);
+
+        return Response::structured([
+            'customers' => $customers->toArray(),
+            'truncated' => $customers->count() === 50,
+        ]);
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to list customers for.')->required(),
+            'search' => $schema->string()->description('Optional filter matched against customer name or email.'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/ListEstimationsTool.php
+++ b/app/Mcp/Tools/ListEstimationsTool.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\Estimation;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('list_estimations')]
+#[Description('List estimations for a given company.')]
+class ListEstimationsTool extends Tool
+{
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        try {
+            $companyId = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+            ])['company_id'];
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $estimations = Estimation::query()
+            ->with('customer')
+            ->where('company_id', $companyId)
+            ->orderByDesc('number')
+            ->limit(50)
+            ->get(['id', 'number', 'customer_id', 'estimation_date', 'expiration_date', 'status'])
+            ->map(fn (Estimation $estimation): array => [
+                'id' => $estimation->id,
+                'number' => $estimation->number,
+                'customer_id' => $estimation->customer_id,
+                'customer_name' => $estimation->customer->name,
+                'estimation_date' => $estimation->estimation_date->format('Y-m-d'),
+                'expiration_date' => $estimation->expiration_date->format('Y-m-d'),
+                'status' => $estimation->status->value,
+            ]);
+
+        return Response::structured([
+            'estimations' => $estimations->toArray(),
+            'truncated' => $estimations->count() === 50,
+        ]);
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to list estimations for.')->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/ListEstimationsTool.php
+++ b/app/Mcp/Tools/ListEstimationsTool.php
@@ -13,9 +13,11 @@ use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 
 #[Name('list_estimations')]
 #[Description('List estimations for a given company.')]
+#[IsReadOnly]
 class ListEstimationsTool extends Tool
 {
     public function handle(Request $request): Response|ResponseFactory

--- a/app/Mcp/Tools/ListInvoicesTool.php
+++ b/app/Mcp/Tools/ListInvoicesTool.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\Invoice;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('list_invoices')]
+#[Description('List invoices for a given company.')]
+class ListInvoicesTool extends Tool
+{
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        try {
+            $companyId = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+            ])['company_id'];
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $invoices = Invoice::query()
+            ->with('customer')
+            ->where('company_id', $companyId)
+            ->orderByDesc('number')
+            ->limit(50)
+            ->get(['id', 'number', 'type', 'customer_id', 'invoice_date', 'paid'])
+            ->map(fn (Invoice $invoice): array => [
+                'id' => $invoice->id,
+                'number' => $invoice->number,
+                'type' => $invoice->type->value,
+                'customer_id' => $invoice->customer_id,
+                'customer_name' => $invoice->customer->name,
+                'invoice_date' => $invoice->invoice_date->format('Y-m-d'),
+                'paid' => $invoice->paid,
+            ]);
+
+        return Response::structured([
+            'invoices' => $invoices->toArray(),
+            'truncated' => $invoices->count() === 50,
+        ]);
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to list invoices for.')->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/ListInvoicesTool.php
+++ b/app/Mcp/Tools/ListInvoicesTool.php
@@ -13,9 +13,11 @@ use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 
 #[Name('list_invoices')]
 #[Description('List invoices for a given company.')]
+#[IsReadOnly]
 class ListInvoicesTool extends Tool
 {
     public function handle(Request $request): Response|ResponseFactory

--- a/app/Mcp/Tools/SendEstimationEmailTool.php
+++ b/app/Mcp/Tools/SendEstimationEmailTool.php
@@ -17,9 +17,13 @@ use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
 
 #[Name('send_estimation_email')]
 #[Description('Email an existing estimation to a recipient.')]
+#[IsDestructive]
+#[IsOpenWorld]
 class SendEstimationEmailTool extends Tool
 {
     public function handle(Request $request): Response|ResponseFactory

--- a/app/Mcp/Tools/SendEstimationEmailTool.php
+++ b/app/Mcp/Tools/SendEstimationEmailTool.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Http\Requests\SendEstimationRequest;
+use App\Mail\EstimationMail;
+use App\Models\Estimation;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('send_estimation_email')]
+#[Description('Email an existing estimation to a recipient.')]
+class SendEstimationEmailTool extends Tool
+{
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        try {
+            $data = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+                'estimation_id' => ['required', 'uuid'],
+            ]);
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $estimation = Estimation::query()->where('company_id', $data['company_id'])->find($data['estimation_id']);
+
+        if ($estimation === null) {
+            return Response::error('No estimation with that id was found for the given company.');
+        }
+
+        try {
+            $mailData = $request->validate((new SendEstimationRequest)->rules());
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        Mail::to($mailData['to'])->send(new EstimationMail($estimation, $mailData['subject'], $mailData['message']));
+
+        $estimation->sent_at = Carbon::now();
+        $estimation->sent_to = $mailData['to'];
+        $estimation->save();
+
+        return Response::structured(['estimation' => $estimation->fresh()->toArray()]);
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company the estimation belongs to.')->required(),
+            'estimation_id' => $schema->string()->description('UUID of the estimation to send.')->required(),
+            'to' => $schema->string()->format('email')->required(),
+            'subject' => $schema->string()->required(),
+            'message' => $schema->string()->description('Email body.')->required(),
+        ];
+    }
+}

--- a/app/Mcp/Tools/SendEstimationEmailTool.php
+++ b/app/Mcp/Tools/SendEstimationEmailTool.php
@@ -37,7 +37,7 @@ class SendEstimationEmailTool extends Tool
             return Response::error($e->validator->errors()->first());
         }
 
-        $estimation = Estimation::query()->where('company_id', $data['company_id'])->find($data['estimation_id']);
+        $estimation = Estimation::query()->where('company_id', (string) $data['company_id'])->find((string) $data['estimation_id']);
 
         if ($estimation === null) {
             return Response::error('No estimation with that id was found for the given company.');

--- a/app/Mcp/Tools/SendInvoiceEmailTool.php
+++ b/app/Mcp/Tools/SendInvoiceEmailTool.php
@@ -17,9 +17,13 @@ use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
 
 #[Name('send_invoice_email')]
 #[Description('Email an existing invoice as a PDF attachment to a recipient.')]
+#[IsDestructive]
+#[IsOpenWorld]
 class SendInvoiceEmailTool extends Tool
 {
     public function handle(Request $request): Response|ResponseFactory

--- a/app/Mcp/Tools/SendInvoiceEmailTool.php
+++ b/app/Mcp/Tools/SendInvoiceEmailTool.php
@@ -37,7 +37,7 @@ class SendInvoiceEmailTool extends Tool
             return Response::error($e->validator->errors()->first());
         }
 
-        $invoice = Invoice::query()->where('company_id', $data['company_id'])->find($data['invoice_id']);
+        $invoice = Invoice::query()->where('company_id', (string) $data['company_id'])->find((string) $data['invoice_id']);
 
         if ($invoice === null) {
             return Response::error('No invoice with that id was found for the given company.');

--- a/app/Mcp/Tools/SendInvoiceEmailTool.php
+++ b/app/Mcp/Tools/SendInvoiceEmailTool.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Http\Requests\SendInvoiceRequest;
+use App\Mail\InvoiceMail;
+use App\Models\Invoice;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('send_invoice_email')]
+#[Description('Email an existing invoice as a PDF attachment to a recipient.')]
+class SendInvoiceEmailTool extends Tool
+{
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        try {
+            $data = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+                'invoice_id' => ['required', 'uuid'],
+            ]);
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $invoice = Invoice::query()->where('company_id', $data['company_id'])->find($data['invoice_id']);
+
+        if ($invoice === null) {
+            return Response::error('No invoice with that id was found for the given company.');
+        }
+
+        try {
+            $mailData = $request->validate((new SendInvoiceRequest)->rules());
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        Mail::to($mailData['to'])->send(new InvoiceMail($invoice, $mailData['subject'], $mailData['message']));
+
+        $invoice->sent_at = Carbon::now();
+        $invoice->sent_to = $mailData['to'];
+        $invoice->save();
+
+        return Response::structured(['invoice' => $invoice->fresh()->toArray()]);
+    }
+
+    /**
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company the invoice belongs to.')->required(),
+            'invoice_id' => $schema->string()->description('UUID of the invoice to send.')->required(),
+            'to' => $schema->string()->format('email')->required(),
+            'subject' => $schema->string()->required(),
+            'message' => $schema->string()->description('Email body.')->required(),
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Carbon;
 use Laravel\Fortify\Contracts\PasskeyUser;
 use Laravel\Fortify\PasskeyAuthenticatable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
+use Laravel\Sanctum\HasApiTokens;
 
 /**
  * @property int $id
@@ -34,7 +35,7 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
 class User extends Authenticatable implements HasLocalePreference, PasskeyUser
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Notifiable, PasskeyAuthenticatable, TwoFactorAuthenticatable;
+    use HasApiTokens, HasFactory, Notifiable, PasskeyAuthenticatable, TwoFactorAuthenticatable;
 
     /**
      * Get the attributes that should be cast.

--- a/app/Support/CurrentCompany.php
+++ b/app/Support/CurrentCompany.php
@@ -3,12 +3,19 @@
 namespace App\Support;
 
 use App\Models\Company;
+use Closure;
 use SortDirection;
 
 class CurrentCompany
 {
+    private static ?Company $override = null;
+
     public static function resolve(): ?Company
     {
+        if (self::$override !== null) {
+            return self::$override;
+        }
+
         $sessionId = session('current_company_id');
 
         if (is_string($sessionId)) {
@@ -21,5 +28,17 @@ class CurrentCompany
 
         return Company::query()->where('is_default', true)->first()
             ?? Company::query()->orderBy('name', SortDirection::Ascending)->first();
+    }
+
+    public static function runningAs(Company $company, Closure $callback): mixed
+    {
+        $previous = self::$override;
+        self::$override = $company;
+
+        try {
+            return $callback();
+        } finally {
+            self::$override = $previous;
+        }
     }
 }

--- a/boost.json
+++ b/boost.json
@@ -11,6 +11,7 @@
         "fortify-development",
         "laravel-best-practices",
         "mcp-development",
+        "passport-development",
         "wayfinder-development",
         "pest-testing",
         "inertia-vue-development",

--- a/boost.json
+++ b/boost.json
@@ -10,6 +10,7 @@
     "skills": [
         "fortify-development",
         "laravel-best-practices",
+        "mcp-development",
         "wayfinder-development",
         "pest-testing",
         "inertia-vue-development",

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "laravel/fortify": "^1.37.2",
         "laravel/framework": "^13.17",
         "laravel/mcp": "^0.9.4",
+        "laravel/passport": "^13.7",
         "laravel/sanctum": "^4.3",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "laravel/chisel": "^0.1.0",
         "laravel/fortify": "^1.37.2",
         "laravel/framework": "^13.17",
+        "laravel/mcp": "^0.9.4",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14",
         "nativephp/desktop": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "laravel/fortify": "^1.37.2",
         "laravel/framework": "^13.17",
         "laravel/mcp": "^0.9.4",
+        "laravel/sanctum": "^4.3",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14",
         "nativephp/desktop": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
             "@php artisan key:generate",
             "@php artisan migrate --force",
+            "@php artisan passport:keys --force",
             "npm install",
             "npm run build"
         ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f4f3168433b1d71c3586bdf2184be24",
+    "content-hash": "cf1f28ca913301fea41c1b148675a3fb",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -315,6 +315,73 @@
                 "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
             },
             "time": "2025-09-16T12:23:56+00:00"
+        },
+        {
+            "name": "defuse/php-encryption",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/defuse/php-encryption.git",
+                "reference": "f53396c2d34225064647a05ca76c1da9d99e5828"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/defuse/php-encryption/zipball/f53396c2d34225064647a05ca76c1da9d99e5828",
+                "reference": "f53396c2d34225064647a05ca76c1da9d99e5828",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "paragonie/random_compat": ">= 2",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5|^6|^7|^8|^9|^10",
+                "yoast/phpunit-polyfills": "^2.0.0"
+            },
+            "bin": [
+                "bin/generate-defuse-key"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Defuse\\Crypto\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Hornby",
+                    "email": "taylor@defuse.ca",
+                    "homepage": "https://defuse.ca/"
+                },
+                {
+                    "name": "Scott Arciszewski",
+                    "email": "info@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "Secure PHP Encryption Library",
+            "keywords": [
+                "aes",
+                "authenticated encryption",
+                "cipher",
+                "crypto",
+                "cryptography",
+                "encrypt",
+                "encryption",
+                "openssl",
+                "security",
+                "symmetric key cryptography"
+            ],
+            "support": {
+                "issues": "https://github.com/defuse/php-encryption/issues",
+                "source": "https://github.com/defuse/php-encryption/tree/v2.4.0"
+            },
+            "time": "2023-06-19T06:10:36+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -891,6 +958,72 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v7.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
+                "phpseclib/phpseclib": "~3.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
+                "phpseclib/phpseclib": "Support PS256 (RSASSA-PSS) signatures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/googleapis/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.1.0"
+            },
+            "time": "2026-06-11T17:54:14+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -2000,6 +2133,81 @@
             "time": "2026-05-18T16:26:00+00:00"
         },
         {
+            "name": "laravel/passport",
+            "version": "v13.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/passport.git",
+                "reference": "980ed27da1da67408754b7e0c13989fe05327d9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/passport/zipball/980ed27da1da67408754b7e0c13989fe05327d9e",
+                "reference": "980ed27da1da67408754b7e0c13989fe05327d9e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "firebase/php-jwt": "^6.4|^7.0",
+                "illuminate/auth": "^11.35|^12.0|^13.0",
+                "illuminate/console": "^11.35|^12.0|^13.0",
+                "illuminate/container": "^11.35|^12.0|^13.0",
+                "illuminate/contracts": "^11.35|^12.0|^13.0",
+                "illuminate/cookie": "^11.35|^12.0|^13.0",
+                "illuminate/database": "^11.35|^12.0|^13.0",
+                "illuminate/encryption": "^11.35|^12.0|^13.0",
+                "illuminate/http": "^11.35|^12.0|^13.0",
+                "illuminate/support": "^11.35|^12.0|^13.0",
+                "league/oauth2-server": "^9.2",
+                "php": "^8.2",
+                "php-http/discovery": "^1.20",
+                "phpseclib/phpseclib": "^3.0",
+                "psr/http-factory-implementation": "*",
+                "symfony/console": "^7.1|^8.0",
+                "symfony/psr-http-message-bridge": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Passport\\PassportServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Passport\\": "src/",
+                    "Laravel\\Passport\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Passport provides OAuth2 server support to Laravel.",
+            "keywords": [
+                "laravel",
+                "oauth",
+                "passport"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/passport/issues",
+                "source": "https://github.com/laravel/passport"
+            },
+            "time": "2026-07-22T09:24:32+00:00"
+        },
+        {
             "name": "laravel/prompts",
             "version": "v0.3.21",
             "source": {
@@ -2315,6 +2523,79 @@
             "time": "2026-05-12T01:44:17+00:00"
         },
         {
+            "name": "lcobucci/jwt",
+            "version": "5.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/clock": "^3.2",
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^11.1"
+            },
+            "suggest": {
+                "lcobucci/clock": ">= 3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/5.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-10-17T11:30:53+00:00"
+        },
+        {
             "name": "league/commonmark",
             "version": "2.8.3",
             "source": {
@@ -2504,6 +2785,65 @@
             "time": "2022-12-11T20:36:23+00:00"
         },
         {
+            "name": "league/event",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/event.git",
+                "reference": "ec38ff7ea10cad7d99a79ac937fbcffb9334c210"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/event/zipball/ec38ff7ea10cad7d99a79ac937fbcffb9334c210",
+                "reference": "ec38ff7ea10cad7d99a79ac937fbcffb9334c210",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0",
+                "psr/event-dispatcher": "^1.0"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "phpstan/phpstan": "^0.12.45",
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Event\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Event package",
+            "keywords": [
+                "emitter",
+                "event",
+                "listener"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/event/issues",
+                "source": "https://github.com/thephpleague/event/tree/3.0.3"
+            },
+            "time": "2024-09-04T16:06:53+00:00"
+        },
+        {
             "name": "league/flysystem",
             "version": "3.35.2",
             "source": {
@@ -2690,6 +3030,103 @@
                 }
             ],
             "time": "2026-07-09T11:49:27+00:00"
+        },
+        {
+            "name": "league/oauth2-server",
+            "version": "9.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-server.git",
+                "reference": "9d2f6fc0a0b5aa1bb02506971d3a4ecff2c6526c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/9d2f6fc0a0b5aa1bb02506971d3a4ecff2c6526c",
+                "reference": "9d2f6fc0a0b5aa1bb02506971d3a4ecff2c6526c",
+                "shasum": ""
+            },
+            "require": {
+                "defuse/php-encryption": "^2.4",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "lcobucci/jwt": "^5.6",
+                "league/event": "^3.0",
+                "league/uri": "^7.8",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/clock": "^1.0",
+                "psr/http-message": "^2.0",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "replace": {
+                "league/oauth2server": "*",
+                "lncd/oauth2": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-diactoros": "^3.8",
+                "paragonie/random_compat": "^9.99.100",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.38",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0.12",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11.5.50",
+                "roave/security-advisories": "dev-master",
+                "slevomat/coding-standard": "^8.27.1",
+                "squizlabs/php_codesniffer": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com",
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andy Millington",
+                    "email": "andrew@noexceptions.io",
+                    "homepage": "https://www.noexceptions.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A lightweight and powerful OAuth 2.0 authorization and resource server library with support for all the core specification grants. This library will allow you to secure your API with OAuth and allow your applications users to approve apps that want to access their data from your API.",
+            "homepage": "https://oauth2.thephpleague.com/",
+            "keywords": [
+                "Authentication",
+                "api",
+                "auth",
+                "authorisation",
+                "authorization",
+                "oauth",
+                "oauth 2",
+                "oauth 2.0",
+                "oauth2",
+                "protect",
+                "resource",
+                "secure",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-server/issues",
+                "source": "https://github.com/thephpleague/oauth2-server/tree/9.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sephster",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-25T15:24:07+00:00"
         },
         {
             "name": "league/uri",
@@ -3689,6 +4126,135 @@
             "time": "2025-09-24T15:06:41+00:00"
         },
         {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "2.2.0",
             "source": {
@@ -3938,6 +4504,116 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "3.0.56",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "7adbbe38cde25e2df2116dbf2673c407e24fa305"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/7adbbe38cde25e2df2116dbf2673c407e24fa305",
+                "reference": "7adbbe38cde25e2df2116dbf2673c407e24fa305",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1|^2|^3",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "ext-dom": "Install the DOM extension to load XML formatted public keys.",
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib3\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.56"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-03T04:36:50+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -4348,6 +5024,119 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/http-server-handler",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-server-handler/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:06:20+00:00"
+        },
+        {
+            "name": "psr/http-server-middleware",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "http",
+                "http-interop",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-middleware/issues",
+                "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
+            },
+            "time": "2023-04-11T06:14:47+00:00"
         },
         {
             "name": "psr/log",
@@ -7396,6 +8185,93 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/property-info/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/psr-http-message-bridge",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/psr-http-message-bridge.git",
+                "reference": "67fd34de15ded1763aa1e330fe345f080a94022c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/67fd34de15ded1763aa1e330fe345f080a94022c",
+                "reference": "67fd34de15ded1763aa1e330fe345f080a94022c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "psr/http-message": "^1.0|^2.0",
+                "symfony/http-foundation": "^7.4|^8.0"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.1",
+                "php-http/discovery": "^1.15",
+                "psr/log": "^1.1.4|^2|^3",
+                "symfony/browser-kit": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/runtime": "^7.4|^8.0"
+            },
+            "type": "symfony-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\PsrHttpMessage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "PSR HTTP message bridge",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v8.1.0"
             },
             "funding": [
                 {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b5da5e3c5ad2242c6d0cf085b47362b",
+    "content-hash": "c5fa93a5e6f63aa08099e1ca4d1f159b",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1856,6 +1856,80 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2026-07-27T14:48:58+00:00"
+        },
+        {
+            "name": "laravel/mcp",
+            "version": "v0.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/mcp.git",
+                "reference": "7ca5b923630118696602d14348cd0466a5e853ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/7ca5b923630118696602d14348cd0466a5e853ec",
+                "reference": "7ca5b923630118696602d14348cd0466a5e853ec",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/json-schema": "^12.41.1|^13.0",
+                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
+                "php": "^8.2",
+                "symfony/process": "^7.4.5|^8.0.5"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.20",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "pestphp/pest": "^3.8.5|^4.3.2",
+                "phpstan/phpstan": "^2.1.27",
+                "rector/rector": "^2.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Mcp": "Laravel\\Mcp\\Facades\\Mcp"
+                    },
+                    "providers": [
+                        "Laravel\\Mcp\\Server\\McpServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Mcp\\": "src/",
+                    "Laravel\\Mcp\\Server\\": "src/Server/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Rapidly build MCP servers for your Laravel applications.",
+            "homepage": "https://github.com/laravel/mcp",
+            "keywords": [
+                "laravel",
+                "mcp"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/mcp/issues",
+                "source": "https://github.com/laravel/mcp"
+            },
+            "time": "2026-08-13T15:01:07+00:00"
         },
         {
             "name": "laravel/passkeys",
@@ -9296,80 +9370,6 @@
                 "source": "https://github.com/laravel/boost"
             },
             "time": "2026-07-17T14:28:57+00:00"
-        },
-        {
-            "name": "laravel/mcp",
-            "version": "v0.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/mcp.git",
-                "reference": "a08884d79a95c5143498507aec5badf751cdbec4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/a08884d79a95c5143498507aec5badf751cdbec4",
-                "reference": "a08884d79a95c5143498507aec5badf751cdbec4",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/json-schema": "^12.41.1|^13.0",
-                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
-                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
-                "php": "^8.2",
-                "symfony/process": "^7.4.5|^8.0.5"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.20",
-                "orchestra/testbench": "^9.15|^10.8|^11.0",
-                "pestphp/pest": "^3.8.5|^4.3.2",
-                "phpstan/phpstan": "^2.1.27",
-                "rector/rector": "^2.2.4"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "aliases": {
-                        "Mcp": "Laravel\\Mcp\\Facades\\Mcp"
-                    },
-                    "providers": [
-                        "Laravel\\Mcp\\Server\\McpServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laravel\\Mcp\\": "src/",
-                    "Laravel\\Mcp\\Server\\": "src/Server/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "Rapidly build MCP servers for your Laravel applications.",
-            "homepage": "https://github.com/laravel/mcp",
-            "keywords": [
-                "laravel",
-                "mcp"
-            ],
-            "support": {
-                "issues": "https://github.com/laravel/mcp/issues",
-                "source": "https://github.com/laravel/mcp"
-            },
-            "time": "2026-07-21T13:23:52+00:00"
         },
         {
             "name": "laravel/pail",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5fa93a5e6f63aa08099e1ca4d1f159b",
+    "content-hash": "2f4f3168433b1d71c3586bdf2184be24",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -2057,6 +2057,69 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.21"
             },
             "time": "2026-06-26T00:11:25+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "fee27a573d1a013af3721d86153a65e0b11927e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/fee27a573d1a013af3721d86153a65e0b11927e6",
+                "reference": "fee27a573d1a013af3721d86153a65e0b11927e6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2026-06-23T18:26:55+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/config/auth.php
+++ b/config/auth.php
@@ -42,6 +42,11 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+
+        'sanctum' => [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+        ],
     ],
 
     /*

--- a/config/auth.php
+++ b/config/auth.php
@@ -47,6 +47,11 @@ return [
             'driver' => 'sanctum',
             'provider' => 'users',
         ],
+
+        'api' => [
+            'driver' => 'passport',
+            'provider' => 'users',
+        ],
     ],
 
     /*

--- a/config/passport.php
+++ b/config/passport.php
@@ -1,0 +1,48 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Passport Guard
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which authentication guard Passport will use when
+    | authenticating users. This value should correspond with one of your
+    | guards that is already present in your "auth" configuration file.
+    |
+    */
+
+    'guard' => 'web',
+
+    'middleware' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption Keys
+    |--------------------------------------------------------------------------
+    |
+    | Passport uses encryption keys while generating secure access tokens for
+    | your application. By default, the keys are stored as local files but
+    | can be set via environment variables when that is more convenient.
+    |
+    */
+
+    'private_key' => env('PASSPORT_PRIVATE_KEY'),
+
+    'public_key' => env('PASSPORT_PUBLIC_KEY'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Passport Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | By default, Passport's models will utilize your application's default
+    | database connection. If you wish to use a different connection you
+    | may specify the configured name of the database connection here.
+    |
+    */
+
+    'connection' => env('PASSPORT_CONNECTION'),
+
+];

--- a/database/migrations/2026_08_17_225349_create_personal_access_tokens_table.php
+++ b/database/migrations/2026_08_17_225349_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/database/migrations/2026_08_18_064056_create_oauth_auth_codes_table.php
+++ b/database/migrations/2026_08_18_064056_create_oauth_auth_codes_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_auth_codes', function (Blueprint $table) {
+            $table->char('id', 80)->primary();
+            $table->foreignId('user_id')->index();
+            $table->foreignUuid('client_id');
+            $table->text('scopes')->nullable();
+            $table->boolean('revoked');
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_auth_codes');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/database/migrations/2026_08_18_064057_create_oauth_access_tokens_table.php
+++ b/database/migrations/2026_08_18_064057_create_oauth_access_tokens_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_access_tokens', function (Blueprint $table) {
+            $table->char('id', 80)->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->foreignUuid('client_id');
+            $table->string('name')->nullable();
+            $table->text('scopes')->nullable();
+            $table->boolean('revoked');
+            $table->timestamps();
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_access_tokens');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/database/migrations/2026_08_18_064058_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2026_08_18_064058_create_oauth_refresh_tokens_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_refresh_tokens', function (Blueprint $table) {
+            $table->char('id', 80)->primary();
+            $table->char('access_token_id', 80)->index();
+            $table->boolean('revoked');
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_refresh_tokens');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/database/migrations/2026_08_18_064059_create_oauth_clients_table.php
+++ b/database/migrations/2026_08_18_064059_create_oauth_clients_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_clients', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->nullableMorphs('owner');
+            $table->string('name');
+            $table->string('secret')->nullable();
+            $table->string('provider')->nullable();
+            $table->text('redirect_uris');
+            $table->text('grant_types');
+            $table->boolean('revoked');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_clients');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/database/migrations/2026_08_18_064100_create_oauth_device_codes_table.php
+++ b/database/migrations/2026_08_18_064100_create_oauth_device_codes_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_device_codes', function (Blueprint $table) {
+            $table->char('id', 80)->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->foreignUuid('client_id')->index();
+            $table->char('user_code', 8)->unique();
+            $table->text('scopes');
+            $table->boolean('revoked');
+            $table->dateTime('user_approved_at')->nullable();
+            $table->dateTime('last_polled_at')->nullable();
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_device_codes');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -96,6 +96,8 @@ if [ "$RUN_MIGRATIONS" = "true" ]; then
     php artisan migrate --force
 fi
 
+[ -f storage/oauth-private.key ] || php artisan passport:keys
+
 php artisan config:cache
 php artisan route:cache
 php artisan view:cache

--- a/docs/superpowers/plans/2026-08-17-mcp-server.md
+++ b/docs/superpowers/plans/2026-08-17-mcp-server.md
@@ -1,0 +1,2156 @@
+# MCP Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose Biglins (customers, estimations, invoices, send-by-email) to AI agents through an MCP server, reachable both as a local/stdio process (NativePHP desktop build) and as an authenticated HTTP endpoint (Docker deployment, potentially internet-exposed).
+
+**Architecture:** A single `App\Mcp\Servers\BiglinsServer` and a set of `App\Mcp\Tools\*` classes are shared between both transports. Each tool takes an explicit `company_id` argument (there is no HTTP session in either transport) and reuses the app's existing `StoreXRequest`/`SendXRequest` validation rule arrays via a new `CurrentCompany::runningAs()` override, so business-rule validation (e.g. "customer_id must belong to this company") isn't duplicated. The web transport is protected by Sanctum personal access tokens, managed from a new Settings > API Tokens page.
+
+**Tech Stack:** Laravel 13, `laravel/mcp` (promoted from dev-only to a real dependency), `laravel/sanctum` (new dependency), Pest, Inertia + Vue 3.
+
+**Spec:** `docs/superpowers/specs/2026-08-17-mcp-server-design.md`
+
+## Global Constraints
+
+- Tool names use snake_case (`list_customers`, `create_customer`, ...), not the package's default kebab-case-from-classname.
+- Every write tool validates `company_id` first (`required|uuid|exists:companies,id`), resolves the `Company`, then runs its business logic inside `CurrentCompany::runningAs($company, fn () => ...)`.
+- Business-rule validation inside a tool reuses the corresponding `App\Http\Requests\*Request::rules()` array via `$request->validate(...)` — never re-declare those rules by hand.
+- `ValidationException` from `$request->validate(...)` is always caught in the tool and turned into `Response::error($e->validator->errors()->first())` — an uncaught exception would surface as a raw JSON-RPC protocol error instead of a normal tool-level error the agent can read.
+- List tools and successful writes return `Response::structured([...])` (not the `@internal`-flagged `Response::json()`), so tests can use `assertStructuredContent(...)`.
+- Every new PHP file follows existing conventions: explicit return types, PHPDoc array shapes, curly braces on all control structures.
+- Run `vendor/bin/pint --dirty --format agent` after any task that touches PHP, before committing.
+
+---
+
+### Task 1: `CurrentCompany::runningAs()` override
+
+**Files:**
+- Modify: `app/Support/CurrentCompany.php`
+- Test: `tests/Feature/CurrentCompanyTest.php`
+
+**Interfaces:**
+- Produces: `CurrentCompany::runningAs(Company $company, Closure $callback): mixed` — every later task's tools call this to scope their logic to an explicit company outside the HTTP session.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/Feature/CurrentCompanyTest.php`:
+
+```php
+test('runningAs overrides resolve for the duration of the closure', function () {
+    $sessionCompany = Company::factory()->create();
+    $overrideCompany = Company::factory()->create();
+    session(['current_company_id' => $sessionCompany->id]);
+
+    $resolvedDuring = CurrentCompany::runningAs($overrideCompany, fn () => CurrentCompany::resolve()?->id);
+
+    expect($resolvedDuring)->toBe($overrideCompany->id);
+    expect(CurrentCompany::resolve()->id)->toBe($sessionCompany->id);
+});
+
+test('runningAs restores the previous override when the closure throws', function () {
+    $company = Company::factory()->create();
+
+    expect(fn () => CurrentCompany::runningAs($company, function () {
+        throw new RuntimeException('boom');
+    }))->toThrow(RuntimeException::class);
+
+    expect(CurrentCompany::resolve())->not->toBe($company);
+});
+
+test('runningAs nests correctly, restoring the outer override on exit', function () {
+    $outer = Company::factory()->create();
+    $inner = Company::factory()->create();
+
+    $result = CurrentCompany::runningAs($outer, function () use ($inner) {
+        $duringInner = CurrentCompany::runningAs($inner, fn () => CurrentCompany::resolve()->id);
+
+        return [$duringInner, CurrentCompany::resolve()->id];
+    });
+
+    expect($result)->toBe([$inner->id, $outer->id]);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `php artisan test --compact --filter=CurrentCompanyTest`
+Expected: FAIL — `Call to undefined method App\Support\CurrentCompany::runningAs()`
+
+- [ ] **Step 3: Implement `runningAs()`**
+
+Replace the full contents of `app/Support/CurrentCompany.php`:
+
+```php
+<?php
+
+namespace App\Support;
+
+use App\Models\Company;
+use Closure;
+use SortDirection;
+
+class CurrentCompany
+{
+    private static ?Company $override = null;
+
+    public static function resolve(): ?Company
+    {
+        if (self::$override !== null) {
+            return self::$override;
+        }
+
+        $sessionId = session('current_company_id');
+
+        if (is_string($sessionId)) {
+            $company = Company::query()->find($sessionId);
+
+            if ($company !== null) {
+                return $company;
+            }
+        }
+
+        return Company::query()->where('is_default', true)->first()
+            ?? Company::query()->orderBy('name', SortDirection::Ascending)->first();
+    }
+
+    public static function runningAs(Company $company, Closure $callback): mixed
+    {
+        $previous = self::$override;
+        self::$override = $company;
+
+        try {
+            return $callback();
+        } finally {
+            self::$override = $previous;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `php artisan test --compact --filter=CurrentCompanyTest`
+Expected: PASS (all tests in the file, including the pre-existing ones)
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add app/Support/CurrentCompany.php tests/Feature/CurrentCompanyTest.php
+git commit -m "feat: add CurrentCompany::runningAs() for non-HTTP company scoping"
+```
+
+---
+
+### Task 2: MCP server foundation + `list_customers`
+
+**Files:**
+- Create: `app/Mcp/Servers/BiglinsServer.php`
+- Create: `app/Mcp/Tools/ListCustomersTool.php`
+- Modify: `routes/ai.php`
+- Modify: `composer.json` (move `laravel/mcp` to `require`)
+- Test: `tests/Feature/Mcp/ListCustomersToolTest.php`
+
+**Interfaces:**
+- Produces: `App\Mcp\Servers\BiglinsServer` (the `$tools` array later tasks append to), the pattern every later tool follows (validate `company_id` → `Response::error` on failure → query → `Response::structured`).
+
+- [ ] **Step 1: Promote `laravel/mcp` to a real dependency**
+
+`laravel/mcp` is currently only in `composer.lock` as a transitive dev dependency of `laravel/boost`. Run:
+
+```bash
+composer require laravel/mcp
+```
+
+Composer resolves this against the already-locked version — expect no version change, just `composer.json`'s `require` section gaining `"laravel/mcp": "^0.9.1"` (or whatever the installed version is) and `composer.lock`'s `packages`/`packages-dev` split updating.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/Feature/Mcp/ListCustomersToolTest.php`:
+
+```php
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\ListCustomersTool;
+use App\Models\Company;
+use App\Models\Customer;
+
+test('list_customers returns customers scoped to the given company', function () {
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    Customer::factory()->count(2)->create(['company_id' => $company->id]);
+    Customer::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(ListCustomersTool::class, [
+        'company_id' => $company->id,
+    ]);
+
+    $response->assertOk();
+    $response->assertStructuredContent(fn ($json) => $json->count('customers', 2)->etc());
+});
+
+test('list_customers filters by the search term', function () {
+    $company = Company::factory()->create();
+    Customer::factory()->create(['company_id' => $company->id, 'name' => 'Acme Corp']);
+    Customer::factory()->create(['company_id' => $company->id, 'name' => 'Globex Inc']);
+
+    $response = BiglinsServer::tool(ListCustomersTool::class, [
+        'company_id' => $company->id,
+        'search' => 'Acme',
+    ]);
+
+    $response->assertOk();
+    $response->assertStructuredContent(fn ($json) => $json
+        ->count('customers', 1)
+        ->where('customers.0.name', 'Acme Corp')
+        ->etc());
+});
+
+test('list_customers rejects a company_id that does not exist', function () {
+    $response = BiglinsServer::tool(ListCustomersTool::class, [
+        'company_id' => (string) Illuminate\Support\Str::uuid(),
+    ]);
+
+    $response->assertHasErrors();
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `php artisan test --compact --filter=ListCustomersToolTest`
+Expected: FAIL — class `App\Mcp\Servers\BiglinsServer` not found
+
+- [ ] **Step 4: Scaffold the server**
+
+Create `app/Mcp/Servers/BiglinsServer.php`:
+
+```php
+<?php
+
+namespace App\Mcp\Servers;
+
+use App\Mcp\Tools\ListCustomersTool;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
+
+#[Name('Biglins')]
+#[Version('1.0.0')]
+#[Instructions('Manage customers, estimations, and invoices for a Biglins company, and send them by email. Every tool takes an explicit company_id — use list_customers/list_estimations/list_invoices to discover existing records before creating new ones.')]
+class BiglinsServer extends Server
+{
+    protected array $tools = [
+        ListCustomersTool::class,
+    ];
+}
+```
+
+- [ ] **Step 5: Write the tool**
+
+Create `app/Mcp/Tools/ListCustomersTool.php`:
+
+```php
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\Customer;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('list_customers')]
+#[Description('List customers for a given company, optionally filtered by a search term matched against name or email.')]
+class ListCustomersTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        try {
+            $data = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+                'search' => ['nullable', 'string'],
+            ]);
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $search = trim($data['search'] ?? '');
+
+        $customers = Customer::query()
+            ->where('company_id', $data['company_id'])
+            ->when($search !== '', fn ($query) => $query->where(function ($query) use ($search) {
+                $query->where('name', 'like', "%{$search}%")
+                    ->orWhere('email', 'like', "%{$search}%");
+            }))
+            ->orderBy('name')
+            ->limit(50)
+            ->get(['id', 'name', 'email', 'city', 'country_id']);
+
+        return Response::structured([
+            'customers' => $customers->toArray(),
+            'truncated' => $customers->count() === 50,
+        ]);
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to list customers for.')->required(),
+            'search' => $schema->string()->description('Optional filter matched against customer name or email.'),
+        ];
+    }
+}
+```
+
+- [ ] **Step 6: Register the local transport**
+
+Replace the contents of `routes/ai.php`:
+
+```php
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use Laravel\Mcp\Facades\Mcp;
+
+Mcp::local('biglins', BiglinsServer::class);
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `php artisan test --compact --filter=ListCustomersToolTest`
+Expected: PASS
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add composer.json composer.lock app/Mcp routes/ai.php tests/Feature/Mcp/ListCustomersToolTest.php
+git commit -m "feat: scaffold MCP server foundation with list_customers tool"
+```
+
+---
+
+### Task 3: `create_customer` tool
+
+**Files:**
+- Create: `app/Mcp/Tools/CreateCustomerTool.php`
+- Modify: `app/Mcp/Servers/BiglinsServer.php` (register the tool)
+- Test: `tests/Feature/Mcp/CreateCustomerToolTest.php`
+
+**Interfaces:**
+- Consumes: `CurrentCompany::runningAs()` from Task 1.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Feature/Mcp/CreateCustomerToolTest.php`:
+
+```php
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\CreateCustomerTool;
+use App\Models\Company;
+use App\Models\Customer;
+
+test('create_customer creates a customer scoped to the given company', function () {
+    $company = Company::factory()->create();
+
+    $response = BiglinsServer::tool(CreateCustomerTool::class, [
+        'company_id' => $company->id,
+        'name' => 'Acme Corp',
+        'email' => 'billing@acme.test',
+    ]);
+
+    $response->assertOk();
+    $customer = Customer::query()->where('name', 'Acme Corp')->firstOrFail();
+    expect($customer->company_id)->toBe($company->id);
+    expect($customer->email)->toBe('billing@acme.test');
+});
+
+test('create_customer requires a name', function () {
+    $company = Company::factory()->create();
+
+    $response = BiglinsServer::tool(CreateCustomerTool::class, [
+        'company_id' => $company->id,
+        'name' => '',
+    ]);
+
+    $response->assertHasErrors();
+    expect(Customer::query()->where('company_id', $company->id)->exists())->toBeFalse();
+});
+
+test('create_customer rejects an invalid email', function () {
+    $company = Company::factory()->create();
+
+    $response = BiglinsServer::tool(CreateCustomerTool::class, [
+        'company_id' => $company->id,
+        'name' => 'Acme Corp',
+        'email' => 'not-an-email',
+    ]);
+
+    $response->assertHasErrors();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `php artisan test --compact --filter=CreateCustomerToolTest`
+Expected: FAIL — class `App\Mcp\Tools\CreateCustomerTool` not found
+
+- [ ] **Step 3: Write the tool**
+
+Create `app/Mcp/Tools/CreateCustomerTool.php`:
+
+```php
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Http\Requests\StoreCustomerRequest;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Support\CurrentCompany;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('create_customer')]
+#[Description('Create a new customer under a given company.')]
+class CreateCustomerTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        try {
+            $companyId = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+            ])['company_id'];
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $company = Company::query()->findOrFail($companyId);
+
+        return CurrentCompany::runningAs($company, function () use ($request, $company): Response {
+            try {
+                $data = $request->validate((new StoreCustomerRequest())->rules());
+            } catch (ValidationException $e) {
+                return Response::error($e->validator->errors()->first());
+            }
+
+            $customer = Customer::query()->create([
+                ...$data,
+                'company_id' => $company->id,
+            ]);
+
+            return Response::structured(['customer' => $customer->toArray()]);
+        });
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to create the customer under.')->required(),
+            'name' => $schema->string()->description('Customer name.')->required(),
+            'address' => $schema->string()->description('Street address.'),
+            'zip' => $schema->string()->description('Postal code.'),
+            'city' => $schema->string(),
+            'country_id' => $schema->string()->description('UUID of an existing country.'),
+            'state' => $schema->string()->description('State or province.'),
+            'email' => $schema->string()->format('email'),
+            'web' => $schema->string()->format('uri'),
+            'phone' => $schema->string(),
+            'nif' => $schema->string()->description('Tax identification number.'),
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Register the tool in the server**
+
+In `app/Mcp/Servers/BiglinsServer.php`, add the import `use App\Mcp\Tools\CreateCustomerTool;` and add `CreateCustomerTool::class,` to the `$tools` array (after `ListCustomersTool::class`).
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `php artisan test --compact --filter=CreateCustomerToolTest`
+Expected: PASS
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add app/Mcp tests/Feature/Mcp/CreateCustomerToolTest.php
+git commit -m "feat: add create_customer MCP tool"
+```
+
+---
+
+### Task 4: `list_estimations` tool
+
+**Files:**
+- Create: `app/Mcp/Tools/ListEstimationsTool.php`
+- Modify: `app/Mcp/Servers/BiglinsServer.php`
+- Test: `tests/Feature/Mcp/ListEstimationsToolTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Feature/Mcp/ListEstimationsToolTest.php`:
+
+```php
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\ListEstimationsTool;
+use App\Models\Company;
+use App\Models\Estimation;
+
+test('list_estimations returns estimations scoped to the given company', function () {
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    Estimation::factory()->count(2)->create(['company_id' => $company->id]);
+    Estimation::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(ListEstimationsTool::class, [
+        'company_id' => $company->id,
+    ]);
+
+    $response->assertOk();
+    $response->assertStructuredContent(fn ($json) => $json->count('estimations', 2)->etc());
+});
+
+test('list_estimations rejects a company_id that does not exist', function () {
+    $response = BiglinsServer::tool(ListEstimationsTool::class, [
+        'company_id' => (string) Illuminate\Support\Str::uuid(),
+    ]);
+
+    $response->assertHasErrors();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `php artisan test --compact --filter=ListEstimationsToolTest`
+Expected: FAIL — class `App\Mcp\Tools\ListEstimationsTool` not found
+
+- [ ] **Step 3: Write the tool**
+
+Create `app/Mcp/Tools/ListEstimationsTool.php`:
+
+```php
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\Estimation;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('list_estimations')]
+#[Description('List estimations for a given company.')]
+class ListEstimationsTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        try {
+            $companyId = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+            ])['company_id'];
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $estimations = Estimation::query()
+            ->with('customer')
+            ->where('company_id', $companyId)
+            ->orderByDesc('number')
+            ->limit(50)
+            ->get(['id', 'number', 'customer_id', 'estimation_date', 'expiration_date', 'status'])
+            ->map(fn (Estimation $estimation): array => [
+                'id' => $estimation->id,
+                'number' => $estimation->number,
+                'customer_id' => $estimation->customer_id,
+                'customer_name' => $estimation->customer->name,
+                'estimation_date' => $estimation->estimation_date->format('Y-m-d'),
+                'expiration_date' => $estimation->expiration_date->format('Y-m-d'),
+                'status' => $estimation->status->value,
+            ]);
+
+        return Response::structured([
+            'estimations' => $estimations->toArray(),
+            'truncated' => $estimations->count() === 50,
+        ]);
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to list estimations for.')->required(),
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Register the tool**
+
+In `app/Mcp/Servers/BiglinsServer.php`, add `use App\Mcp\Tools\ListEstimationsTool;` and append `ListEstimationsTool::class,` to `$tools`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `php artisan test --compact --filter=ListEstimationsToolTest`
+Expected: PASS
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add app/Mcp tests/Feature/Mcp/ListEstimationsToolTest.php
+git commit -m "feat: add list_estimations MCP tool"
+```
+
+---
+
+### Task 5: `create_estimation` tool
+
+**Files:**
+- Create: `app/Mcp/Tools/CreateEstimationTool.php`
+- Modify: `app/Mcp/Servers/BiglinsServer.php`
+- Test: `tests/Feature/Mcp/CreateEstimationToolTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Feature/Mcp/CreateEstimationToolTest.php`:
+
+```php
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\CreateEstimationTool;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Models\Estimation;
+
+test('create_estimation creates an estimation with rows scoped to the given company', function () {
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $response = BiglinsServer::tool(CreateEstimationTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'estimation_date' => '2026-08-17',
+        'expiration_date' => '2026-09-17',
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Consulting', 'quantity' => 2, 'price' => 100, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertOk();
+    $estimation = Estimation::query()->where('company_id', $company->id)->firstOrFail();
+    expect($estimation->customer_id)->toBe($customer->id);
+    expect($estimation->rows)->toHaveCount(1);
+    expect((float) $estimation->rows->first()->price)->toBe(100.0);
+});
+
+test('create_estimation rejects a customer_id belonging to another company', function () {
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(CreateEstimationTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'estimation_date' => '2026-08-17',
+        'expiration_date' => '2026-09-17',
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Consulting', 'quantity' => 1, 'price' => 100, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertHasErrors();
+    expect(Estimation::query()->where('company_id', $company->id)->exists())->toBeFalse();
+});
+
+test('create_estimation requires at least one row', function () {
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $response = BiglinsServer::tool(CreateEstimationTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'estimation_date' => '2026-08-17',
+        'expiration_date' => '2026-09-17',
+        'language' => 'en',
+        'rows' => [],
+    ]);
+
+    $response->assertHasErrors();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `php artisan test --compact --filter=CreateEstimationToolTest`
+Expected: FAIL — class `App\Mcp\Tools\CreateEstimationTool` not found
+
+- [ ] **Step 3: Write the tool**
+
+Create `app/Mcp/Tools/CreateEstimationTool.php`:
+
+```php
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Http\Requests\StoreEstimationRequest;
+use App\Models\Company;
+use App\Models\Estimation;
+use App\Support\CurrentCompany;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('create_estimation')]
+#[Description('Create a new estimation with line items for an existing customer.')]
+class CreateEstimationTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        try {
+            $companyId = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+            ])['company_id'];
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $company = Company::query()->findOrFail($companyId);
+
+        return CurrentCompany::runningAs($company, function () use ($request, $company): Response {
+            try {
+                $data = $request->validate((new StoreEstimationRequest())->rules());
+            } catch (ValidationException $e) {
+                return Response::error($e->validator->errors()->first());
+            }
+
+            $estimation = DB::transaction(function () use ($data, $company): Estimation {
+                $estimation = Estimation::query()->create([
+                    ...collect($data)->except('rows')->all(),
+                    'company_id' => $company->id,
+                ]);
+
+                $estimation->rows()->createMany($data['rows']);
+
+                return $estimation;
+            });
+
+            return Response::structured(['estimation' => $estimation->load('rows')->toArray()]);
+        });
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to create the estimation under.')->required(),
+            'customer_id' => $schema->string()->description('UUID of an existing customer belonging to the company.')->required(),
+            'estimation_date' => $schema->string()->format('date')->description('YYYY-MM-DD.')->required(),
+            'expiration_date' => $schema->string()->format('date')->description('YYYY-MM-DD, must be on or after estimation_date.')->required(),
+            'language' => $schema->string()->enum(['it', 'en', 'es'])->required(),
+            'body' => $schema->string()->description('Optional markdown body/notes.'),
+            'rows' => $schema->array()->items(
+                $schema->object([
+                    'description' => $schema->string()->required(),
+                    'quantity' => $schema->number()->required(),
+                    'price' => $schema->number()->required(),
+                    'vat_rate' => $schema->number()->required(),
+                    'note' => $schema->string(),
+                ])
+            )->description('Line items, at least one required.')->required(),
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Register the tool**
+
+In `app/Mcp/Servers/BiglinsServer.php`, add `use App\Mcp\Tools\CreateEstimationTool;` and append `CreateEstimationTool::class,` to `$tools`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `php artisan test --compact --filter=CreateEstimationToolTest`
+Expected: PASS
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add app/Mcp tests/Feature/Mcp/CreateEstimationToolTest.php
+git commit -m "feat: add create_estimation MCP tool"
+```
+
+---
+
+### Task 6: `list_invoices` tool
+
+**Files:**
+- Create: `app/Mcp/Tools/ListInvoicesTool.php`
+- Modify: `app/Mcp/Servers/BiglinsServer.php`
+- Test: `tests/Feature/Mcp/ListInvoicesToolTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Feature/Mcp/ListInvoicesToolTest.php`:
+
+```php
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\ListInvoicesTool;
+use App\Models\Company;
+use App\Models\Invoice;
+
+test('list_invoices returns invoices scoped to the given company', function () {
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    Invoice::factory()->count(2)->create(['company_id' => $company->id]);
+    Invoice::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(ListInvoicesTool::class, [
+        'company_id' => $company->id,
+    ]);
+
+    $response->assertOk();
+    $response->assertStructuredContent(fn ($json) => $json->count('invoices', 2)->etc());
+});
+
+test('list_invoices rejects a company_id that does not exist', function () {
+    $response = BiglinsServer::tool(ListInvoicesTool::class, [
+        'company_id' => (string) Illuminate\Support\Str::uuid(),
+    ]);
+
+    $response->assertHasErrors();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `php artisan test --compact --filter=ListInvoicesToolTest`
+Expected: FAIL — class `App\Mcp\Tools\ListInvoicesTool` not found
+
+- [ ] **Step 3: Write the tool**
+
+Create `app/Mcp/Tools/ListInvoicesTool.php`:
+
+```php
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\Invoice;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('list_invoices')]
+#[Description('List invoices for a given company.')]
+class ListInvoicesTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        try {
+            $companyId = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+            ])['company_id'];
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $invoices = Invoice::query()
+            ->with('customer')
+            ->where('company_id', $companyId)
+            ->orderByDesc('number')
+            ->limit(50)
+            ->get(['id', 'number', 'type', 'customer_id', 'invoice_date', 'paid'])
+            ->map(fn (Invoice $invoice): array => [
+                'id' => $invoice->id,
+                'number' => $invoice->number,
+                'type' => $invoice->type->value,
+                'customer_id' => $invoice->customer_id,
+                'customer_name' => $invoice->customer->name,
+                'invoice_date' => $invoice->invoice_date->format('Y-m-d'),
+                'paid' => $invoice->paid,
+            ]);
+
+        return Response::structured([
+            'invoices' => $invoices->toArray(),
+            'truncated' => $invoices->count() === 50,
+        ]);
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to list invoices for.')->required(),
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Register the tool**
+
+In `app/Mcp/Servers/BiglinsServer.php`, add `use App\Mcp\Tools\ListInvoicesTool;` and append `ListInvoicesTool::class,` to `$tools`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `php artisan test --compact --filter=ListInvoicesToolTest`
+Expected: PASS
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add app/Mcp tests/Feature/Mcp/ListInvoicesToolTest.php
+git commit -m "feat: add list_invoices MCP tool"
+```
+
+---
+
+### Task 7: `create_invoice` tool
+
+**Files:**
+- Create: `app/Mcp/Tools/CreateInvoiceTool.php`
+- Modify: `app/Mcp/Servers/BiglinsServer.php`
+- Test: `tests/Feature/Mcp/CreateInvoiceToolTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Feature/Mcp/CreateInvoiceToolTest.php`:
+
+```php
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\CreateInvoiceTool;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Models\Invoice;
+
+test('create_invoice creates an invoice with rows scoped to the given company', function () {
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $response = BiglinsServer::tool(CreateInvoiceTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'invoice_date' => '2026-08-17',
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Consulting', 'quantity' => 1, 'price' => 200, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertOk();
+    $invoice = Invoice::query()->where('company_id', $company->id)->firstOrFail();
+    expect($invoice->customer_id)->toBe($customer->id);
+    expect((float) $invoice->rows->first()->price)->toBe(200.0);
+});
+
+test('create_invoice negates row prices for a credit note', function () {
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $response = BiglinsServer::tool(CreateInvoiceTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'type' => 'credit_note',
+        'invoice_date' => '2026-08-17',
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Refund', 'quantity' => 1, 'price' => 50, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertOk();
+    $invoice = Invoice::query()->where('company_id', $company->id)->firstOrFail();
+    expect((float) $invoice->rows->first()->price)->toBe(-50.0);
+});
+
+test('create_invoice rejects a customer_id belonging to another company', function () {
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(CreateInvoiceTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'invoice_date' => '2026-08-17',
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Consulting', 'quantity' => 1, 'price' => 100, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertHasErrors();
+    expect(Invoice::query()->where('company_id', $company->id)->exists())->toBeFalse();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `php artisan test --compact --filter=CreateInvoiceToolTest`
+Expected: FAIL — class `App\Mcp\Tools\CreateInvoiceTool` not found
+
+- [ ] **Step 3: Write the tool**
+
+Create `app/Mcp/Tools/CreateInvoiceTool.php`:
+
+```php
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Enums\InvoiceType;
+use App\Http\Requests\StoreInvoiceRequest;
+use App\Models\Company;
+use App\Models\Invoice;
+use App\Support\CurrentCompany;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('create_invoice')]
+#[Description('Create a new invoice (or credit note) with line items for an existing customer.')]
+class CreateInvoiceTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        try {
+            $companyId = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+            ])['company_id'];
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $company = Company::query()->findOrFail($companyId);
+
+        return CurrentCompany::runningAs($company, function () use ($request, $company): Response {
+            try {
+                $data = $request->validate((new StoreInvoiceRequest())->rules());
+            } catch (ValidationException $e) {
+                return Response::error($e->validator->errors()->first());
+            }
+
+            $invoice = DB::transaction(function () use ($data, $company): Invoice {
+                $invoice = Invoice::query()->create([
+                    ...collect($data)->except('rows')->all(),
+                    'company_id' => $company->id,
+                ]);
+
+                $type = $invoice->type;
+                $rows = collect($data['rows'])->map(function (array $row) use ($type): array {
+                    if ($type === InvoiceType::CreditNote) {
+                        $row['price'] = -abs((float) $row['price']);
+                    }
+
+                    return $row;
+                });
+
+                $invoice->rows()->createMany($rows);
+
+                return $invoice;
+            });
+
+            return Response::structured(['invoice' => $invoice->load('rows')->toArray()]);
+        });
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company to create the invoice under.')->required(),
+            'customer_id' => $schema->string()->description('UUID of an existing customer belonging to the company.')->required(),
+            'type' => $schema->string()->enum(['invoice', 'credit_note'])->description('Defaults to invoice.'),
+            'invoice_date' => $schema->string()->format('date')->description('YYYY-MM-DD.')->required(),
+            'note' => $schema->string(),
+            'language' => $schema->string()->enum(['it', 'en', 'es'])->required(),
+            'rows' => $schema->array()->items(
+                $schema->object([
+                    'description' => $schema->string()->required(),
+                    'quantity' => $schema->number()->required(),
+                    'price' => $schema->number()->required(),
+                    'vat_rate' => $schema->number()->required(),
+                    'expiration_date' => $schema->string()->format('date'),
+                ])
+            )->description('Line items, at least one required.')->required(),
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Register the tool**
+
+In `app/Mcp/Servers/BiglinsServer.php`, add `use App\Mcp\Tools\CreateInvoiceTool;` and append `CreateInvoiceTool::class,` to `$tools`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `php artisan test --compact --filter=CreateInvoiceToolTest`
+Expected: PASS
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add app/Mcp tests/Feature/Mcp/CreateInvoiceToolTest.php
+git commit -m "feat: add create_invoice MCP tool"
+```
+
+---
+
+### Task 8: `send_invoice_email` tool
+
+**Files:**
+- Create: `app/Mcp/Tools/SendInvoiceEmailTool.php`
+- Modify: `app/Mcp/Servers/BiglinsServer.php`
+- Test: `tests/Feature/Mcp/SendInvoiceEmailToolTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Feature/Mcp/SendInvoiceEmailToolTest.php`:
+
+```php
+<?php
+
+use App\Mail\InvoiceMail;
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\SendInvoiceEmailTool;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Models\Invoice;
+use Illuminate\Support\Facades\Mail;
+
+test('send_invoice_email sends the invoice and records who it was sent to', function () {
+    Mail::fake();
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+    $invoice = Invoice::factory()->create(['company_id' => $company->id, 'customer_id' => $customer->id]);
+
+    $response = BiglinsServer::tool(SendInvoiceEmailTool::class, [
+        'company_id' => $company->id,
+        'invoice_id' => $invoice->id,
+        'to' => 'client@example.test',
+        'subject' => 'Your invoice',
+        'message' => 'Please find your invoice attached.',
+    ]);
+
+    $response->assertOk();
+    Mail::assertSent(InvoiceMail::class);
+    expect($invoice->fresh()->sent_to)->toBe('client@example.test');
+    expect($invoice->fresh()->sent_at)->not->toBeNull();
+});
+
+test('send_invoice_email rejects an invoice belonging to another company', function () {
+    Mail::fake();
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    $invoice = Invoice::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(SendInvoiceEmailTool::class, [
+        'company_id' => $company->id,
+        'invoice_id' => $invoice->id,
+        'to' => 'client@example.test',
+        'subject' => 'Your invoice',
+        'message' => 'Please find your invoice attached.',
+    ]);
+
+    $response->assertHasErrors();
+    Mail::assertNotSent(InvoiceMail::class);
+});
+
+test('send_invoice_email requires a valid recipient email', function () {
+    Mail::fake();
+    $company = Company::factory()->create();
+    $invoice = Invoice::factory()->create(['company_id' => $company->id]);
+
+    $response = BiglinsServer::tool(SendInvoiceEmailTool::class, [
+        'company_id' => $company->id,
+        'invoice_id' => $invoice->id,
+        'to' => 'not-an-email',
+        'subject' => 'Your invoice',
+        'message' => 'Please find your invoice attached.',
+    ]);
+
+    $response->assertHasErrors();
+    Mail::assertNotSent(InvoiceMail::class);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `php artisan test --compact --filter=SendInvoiceEmailToolTest`
+Expected: FAIL — class `App\Mcp\Tools\SendInvoiceEmailTool` not found
+
+- [ ] **Step 3: Write the tool**
+
+Create `app/Mcp/Tools/SendInvoiceEmailTool.php`:
+
+```php
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Http\Requests\SendInvoiceRequest;
+use App\Mail\InvoiceMail;
+use App\Models\Invoice;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('send_invoice_email')]
+#[Description('Email an existing invoice as a PDF attachment to a recipient.')]
+class SendInvoiceEmailTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        try {
+            $data = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+                'invoice_id' => ['required', 'uuid'],
+            ]);
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $invoice = Invoice::query()->where('company_id', $data['company_id'])->find($data['invoice_id']);
+
+        if ($invoice === null) {
+            return Response::error('No invoice with that id was found for the given company.');
+        }
+
+        try {
+            $mailData = $request->validate((new SendInvoiceRequest())->rules());
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        Mail::to($mailData['to'])->send(new InvoiceMail($invoice, $mailData['subject'], $mailData['message']));
+
+        $invoice->sent_at = Carbon::now();
+        $invoice->sent_to = $mailData['to'];
+        $invoice->save();
+
+        return Response::structured(['invoice' => $invoice->fresh()->toArray()]);
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company the invoice belongs to.')->required(),
+            'invoice_id' => $schema->string()->description('UUID of the invoice to send.')->required(),
+            'to' => $schema->string()->format('email')->required(),
+            'subject' => $schema->string()->required(),
+            'message' => $schema->string()->description('Email body.')->required(),
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Register the tool**
+
+In `app/Mcp/Servers/BiglinsServer.php`, add `use App\Mcp\Tools\SendInvoiceEmailTool;` and append `SendInvoiceEmailTool::class,` to `$tools`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `php artisan test --compact --filter=SendInvoiceEmailToolTest`
+Expected: PASS
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add app/Mcp tests/Feature/Mcp/SendInvoiceEmailToolTest.php
+git commit -m "feat: add send_invoice_email MCP tool"
+```
+
+---
+
+### Task 9: `send_estimation_email` tool
+
+**Files:**
+- Create: `app/Mcp/Tools/SendEstimationEmailTool.php`
+- Modify: `app/Mcp/Servers/BiglinsServer.php`
+- Test: `tests/Feature/Mcp/SendEstimationEmailToolTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Feature/Mcp/SendEstimationEmailToolTest.php`:
+
+```php
+<?php
+
+use App\Mail\EstimationMail;
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\SendEstimationEmailTool;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Models\Estimation;
+use Illuminate\Support\Facades\Mail;
+
+test('send_estimation_email sends the estimation and records who it was sent to', function () {
+    Mail::fake();
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+    $estimation = Estimation::factory()->create(['company_id' => $company->id, 'customer_id' => $customer->id]);
+
+    $response = BiglinsServer::tool(SendEstimationEmailTool::class, [
+        'company_id' => $company->id,
+        'estimation_id' => $estimation->id,
+        'to' => 'client@example.test',
+        'subject' => 'Your estimation',
+        'message' => 'Please find your estimation attached.',
+    ]);
+
+    $response->assertOk();
+    Mail::assertSent(EstimationMail::class);
+    expect($estimation->fresh()->sent_to)->toBe('client@example.test');
+    expect($estimation->fresh()->sent_at)->not->toBeNull();
+});
+
+test('send_estimation_email rejects an estimation belonging to another company', function () {
+    Mail::fake();
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    $estimation = Estimation::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(SendEstimationEmailTool::class, [
+        'company_id' => $company->id,
+        'estimation_id' => $estimation->id,
+        'to' => 'client@example.test',
+        'subject' => 'Your estimation',
+        'message' => 'Please find your estimation attached.',
+    ]);
+
+    $response->assertHasErrors();
+    Mail::assertNotSent(EstimationMail::class);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `php artisan test --compact --filter=SendEstimationEmailToolTest`
+Expected: FAIL — class `App\Mcp\Tools\SendEstimationEmailTool` not found
+
+- [ ] **Step 3: Write the tool**
+
+Create `app/Mcp/Tools/SendEstimationEmailTool.php`:
+
+```php
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Http\Requests\SendEstimationRequest;
+use App\Mail\EstimationMail;
+use App\Models\Estimation;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+
+#[Name('send_estimation_email')]
+#[Description('Email an existing estimation to a recipient.')]
+class SendEstimationEmailTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        try {
+            $data = $request->validate([
+                'company_id' => ['required', 'uuid', Rule::exists('companies', 'id')],
+                'estimation_id' => ['required', 'uuid'],
+            ]);
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        $estimation = Estimation::query()->where('company_id', $data['company_id'])->find($data['estimation_id']);
+
+        if ($estimation === null) {
+            return Response::error('No estimation with that id was found for the given company.');
+        }
+
+        try {
+            $mailData = $request->validate((new SendEstimationRequest())->rules());
+        } catch (ValidationException $e) {
+            return Response::error($e->validator->errors()->first());
+        }
+
+        Mail::to($mailData['to'])->send(new EstimationMail($estimation, $mailData['subject'], $mailData['message']));
+
+        $estimation->sent_at = Carbon::now();
+        $estimation->sent_to = $mailData['to'];
+        $estimation->save();
+
+        return Response::structured(['estimation' => $estimation->fresh()->toArray()]);
+    }
+
+    /**
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'company_id' => $schema->string()->description('UUID of the company the estimation belongs to.')->required(),
+            'estimation_id' => $schema->string()->description('UUID of the estimation to send.')->required(),
+            'to' => $schema->string()->format('email')->required(),
+            'subject' => $schema->string()->required(),
+            'message' => $schema->string()->description('Email body.')->required(),
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Register the tool**
+
+In `app/Mcp/Servers/BiglinsServer.php`, add `use App\Mcp\Tools\SendEstimationEmailTool;` and append `SendEstimationEmailTool::class,` to `$tools`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `php artisan test --compact --filter=SendEstimationEmailToolTest`
+Expected: PASS
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add app/Mcp tests/Feature/Mcp/SendEstimationEmailToolTest.php
+git commit -m "feat: add send_estimation_email MCP tool"
+```
+
+---
+
+### Task 10: Sanctum + web transport
+
+**Files:**
+- Modify: `composer.json` (add `laravel/sanctum`)
+- Modify: `config/auth.php` (register the `sanctum` guard)
+- Modify: `app/Models/User.php` (add `HasApiTokens`)
+- Modify: `routes/ai.php` (register `Mcp::web()`)
+- Create: migration (via `vendor:publish`)
+- Test: `tests/Feature/Mcp/WebTransportAuthTest.php`
+
+**Interfaces:**
+- Produces: `$user->createToken($name)` usable by Task 11's controller.
+
+- [ ] **Step 1: Install Sanctum**
+
+```bash
+composer require laravel/sanctum
+php artisan vendor:publish --provider="Laravel\Sanctum\SanctumServiceProvider" --tag="sanctum-migrations"
+```
+
+This creates a new migration file under `database/migrations/` for the `personal_access_tokens` table (standard Sanctum schema — do not hand-edit it).
+
+- [ ] **Step 2: Register the `sanctum` guard**
+
+In `config/auth.php`, inside the `'guards'` array (after the existing `'web'` entry), add:
+
+```php
+        'sanctum' => [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+        ],
+```
+
+- [ ] **Step 3: Add `HasApiTokens` to the User model**
+
+In `app/Models/User.php`, add the import `use Laravel\Sanctum\HasApiTokens;` and add `HasApiTokens` to the existing `use HasFactory, Notifiable, PasskeyAuthenticatable, TwoFactorAuthenticatable;` trait list (becomes `use HasApiTokens, HasFactory, Notifiable, PasskeyAuthenticatable, TwoFactorAuthenticatable;`).
+
+- [ ] **Step 4: Run the migration**
+
+```bash
+php artisan migrate
+```
+
+- [ ] **Step 5: Write the failing test**
+
+Create `tests/Feature/Mcp/WebTransportAuthTest.php`:
+
+```php
+<?php
+
+use App\Models\User;
+
+test('the web MCP endpoint rejects requests without a token', function () {
+    $response = $this->postJson('/mcp/biglins', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+    ], ['Accept' => 'application/json, text/event-stream']);
+
+    $response->assertUnauthorized();
+});
+
+test('the web MCP endpoint accepts a valid Sanctum token', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('agent')->plainTextToken;
+
+    $response = $this->postJson('/mcp/biglins', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+    ], [
+        'Accept' => 'application/json, text/event-stream',
+        'Authorization' => "Bearer {$token}",
+    ]);
+
+    $response->assertOk();
+});
+```
+
+- [ ] **Step 6: Run the test to verify it fails**
+
+Run: `php artisan test --compact --filter=WebTransportAuthTest`
+Expected: FAIL — 404 (no `/mcp/biglins` route registered yet)
+
+- [ ] **Step 7: Register the web transport**
+
+Replace the contents of `routes/ai.php`:
+
+```php
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use Laravel\Mcp\Facades\Mcp;
+
+Mcp::local('biglins', BiglinsServer::class);
+
+Mcp::web('/mcp/biglins', BiglinsServer::class)->middleware('auth:sanctum');
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `php artisan test --compact --filter=WebTransportAuthTest`
+Expected: PASS
+
+- [ ] **Step 9: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add composer.json composer.lock config/auth.php app/Models/User.php routes/ai.php database/migrations tests/Feature/Mcp/WebTransportAuthTest.php
+git commit -m "feat: add Sanctum-authenticated web transport for the MCP server"
+```
+
+---
+
+### Task 11: Settings > API Tokens — backend
+
+**Files:**
+- Create: `app/Http/Controllers/Settings/ApiTokenController.php`
+- Create: `app/Http/Requests/Settings/StoreApiTokenRequest.php`
+- Modify: `routes/settings.php`
+- Test: `tests/Feature/Settings/ApiTokensTest.php`
+
+**Interfaces:**
+- Produces: routes `api-tokens.index` (GET), `api-tokens.store` (POST), `api-tokens.destroy` (DELETE) — consumed by Task 12's Vue page.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Feature/Settings/ApiTokensTest.php`:
+
+```php
+<?php
+
+use App\Models\User;
+
+test('guests are redirected to the login page when visiting api tokens settings', function () {
+    $this->get(route('api-tokens.index'))->assertRedirect(route('login'));
+});
+
+test('api tokens settings page lists the user\'s tokens', function () {
+    $user = User::factory()->create();
+    $user->createToken('laptop');
+
+    $response = $this->actingAs($user)->get(route('api-tokens.index'));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page->component('settings/ApiTokens')
+        ->has('tokens', 1)
+        ->where('tokens.0.name', 'laptop'));
+});
+
+test('a token can be created and the plaintext value is returned once', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post(route('api-tokens.store'), [
+        'name' => 'agent-1',
+    ]);
+
+    $response->assertSessionHasNoErrors()->assertRedirect(route('api-tokens.index'));
+    expect($user->fresh()->tokens)->toHaveCount(1);
+    expect($user->fresh()->tokens->first()->name)->toBe('agent-1');
+});
+
+test('a token name is required', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post(route('api-tokens.store'), ['name' => '']);
+
+    $response->assertSessionHasErrors('name');
+});
+
+test('a token can be revoked', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('laptop');
+
+    $response = $this->actingAs($user)->delete(route('api-tokens.destroy', $token->accessToken->id));
+
+    $response->assertRedirect(route('api-tokens.index'));
+    expect($user->fresh()->tokens)->toHaveCount(0);
+});
+
+test('a user cannot revoke another user\'s token', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $token = $otherUser->createToken('laptop');
+
+    $response = $this->actingAs($user)->delete(route('api-tokens.destroy', $token->accessToken->id));
+
+    $response->assertForbidden();
+    expect($otherUser->fresh()->tokens)->toHaveCount(1);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `php artisan test --compact --filter=ApiTokensTest`
+Expected: FAIL — `route('api-tokens.index')` undefined
+
+- [ ] **Step 3: Write the form request**
+
+Create `app/Http/Requests/Settings/StoreApiTokenRequest.php`:
+
+```php
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreApiTokenRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Write the controller**
+
+Create `app/Http/Controllers/Settings/ApiTokenController.php`:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\StoreApiTokenRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+use Inertia\Response;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class ApiTokenController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('settings/ApiTokens', [
+            'tokens' => request()->user()
+                ->tokens()
+                ->select(['id', 'name', 'created_at', 'last_used_at'])
+                ->latest()
+                ->get()
+                ->map(fn (PersonalAccessToken $token): array => [
+                    'id' => $token->id,
+                    'name' => $token->name,
+                    'created_at_diff' => $token->created_at?->diffForHumans(),
+                    'last_used_at_diff' => $token->last_used_at?->diffForHumans(),
+                ])
+                ->values()
+                ->all(),
+        ]);
+    }
+
+    public function store(StoreApiTokenRequest $request): RedirectResponse
+    {
+        $token = $request->user()->createToken($request->validated('name'));
+
+        Inertia::flash('newApiToken', $token->plainTextToken);
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('API token created.')]);
+
+        return to_route('api-tokens.index');
+    }
+
+    public function destroy(int $token): RedirectResponse
+    {
+        $accessToken = PersonalAccessToken::query()->findOrFail($token);
+
+        abort_unless($accessToken->tokenable_id === request()->user()->id, 403);
+
+        $accessToken->delete();
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('API token revoked.')]);
+
+        return to_route('api-tokens.index');
+    }
+}
+```
+
+- [ ] **Step 5: Register the routes**
+
+In `routes/settings.php`, add the import `use App\Http\Controllers\Settings\ApiTokenController;`, then inside the existing `Route::middleware(['auth', 'verified'])->group(function () { ... })` block (after the `security.edit` route), add:
+
+```php
+    Route::get('settings/api-tokens', [ApiTokenController::class, 'index'])->name('api-tokens.index');
+    Route::post('settings/api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
+    Route::delete('settings/api-tokens/{token}', [ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `php artisan test --compact --filter=ApiTokensTest`
+Expected: PASS
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+vendor/bin/pint --dirty --format agent
+git add app/Http/Controllers/Settings/ApiTokenController.php app/Http/Requests/Settings/StoreApiTokenRequest.php routes/settings.php tests/Feature/Settings/ApiTokensTest.php
+git commit -m "feat: add Settings > API Tokens backend"
+```
+
+---
+
+### Task 12: Settings > API Tokens — frontend
+
+**Files:**
+- Create: `resources/js/pages/settings/ApiTokens.vue`
+- Modify: `resources/js/layouts/settings/Layout.vue` (nav entry)
+- Modify: `resources/js/lang/en.ts`, `resources/js/lang/it.ts`, `resources/js/lang/es.ts` (translation keys)
+
+**Interfaces:**
+- Consumes: `tokens` prop shape `{id: number, name: string, created_at_diff: string|null, last_used_at_diff: string|null}[]` and flash keys `newApiToken`/`toast` from Task 11's controller; routes `api-tokens.index`/`api-tokens.store`/`api-tokens.destroy` generated by Wayfinder from those same routes.
+
+- [ ] **Step 1: Generate Wayfinder actions for the new routes**
+
+```bash
+php artisan wayfinder:generate
+```
+
+This regenerates `resources/js/actions/App/Http/Controllers/Settings/ApiTokenController.ts` and `resources/js/routes/api-tokens/index.ts` (or equivalent, following the existing `routes/security.ts`/`actions/.../SecurityController.ts` naming already in the project) — inspect the generated files after running this command rather than guessing their exact export names, since Wayfinder's output layout is derived mechanically from `routes/settings.php`.
+
+- [ ] **Step 2: Add translation keys**
+
+In `resources/js/lang/en.ts`, inside the `settings` object, add a `nav.apiTokens` entry alongside the existing `nav` keys and a new `apiTokens` section alongside `language`/`profile`:
+
+```ts
+        nav: {
+            profile: 'Profile',
+            security: 'Security',
+            appearance: 'Appearance',
+            language: 'Language',
+            apiTokens: 'API Tokens',
+        },
+```
+
+```ts
+        apiTokens: {
+            title: 'API tokens',
+            pageTitle: 'API token settings',
+            description:
+                'Create tokens to let AI agents connect to this Biglins instance over the MCP server.',
+            namePlaceholder: 'Token name (e.g. "agent-1")',
+            create: 'Create token',
+            empty: 'No API tokens yet.',
+            createdAt: 'Created {time}',
+            lastUsedAt: 'Last used {time}',
+            neverUsed: 'Never used',
+            revoke: 'Revoke',
+            confirmRevoke: 'Revoke this token? Any agent using it will lose access immediately.',
+            newTokenTitle: 'Copy your new token now',
+            newTokenDescription:
+                "This is the only time it will be shown. Store it somewhere safe — it won't be recoverable afterwards.",
+            copy: 'Copy',
+            copied: 'Copied!',
+        },
+```
+
+Mirror the same two additions in `resources/js/lang/it.ts`:
+
+```ts
+        nav: {
+            profile: 'Profilo',
+            security: 'Sicurezza',
+            appearance: 'Aspetto',
+            language: 'Lingua',
+            apiTokens: 'Token API',
+        },
+```
+
+```ts
+        apiTokens: {
+            title: 'Token API',
+            pageTitle: 'Impostazioni token API',
+            description:
+                'Crea token per permettere agli agenti AI di collegarsi a questa istanza di Biglins tramite il server MCP.',
+            namePlaceholder: 'Nome del token (es. "agente-1")',
+            create: 'Crea token',
+            empty: 'Nessun token API.',
+            createdAt: 'Creato {time}',
+            lastUsedAt: 'Ultimo utilizzo {time}',
+            neverUsed: 'Mai utilizzato',
+            revoke: 'Revoca',
+            confirmRevoke: 'Revocare questo token? Ogni agente che lo usa perderà l\'accesso immediatamente.',
+            newTokenTitle: 'Copia subito il tuo nuovo token',
+            newTokenDescription:
+                'Verrà mostrato solo questa volta. Conservalo in un posto sicuro: non potrà essere recuperato in seguito.',
+            copy: 'Copia',
+            copied: 'Copiato!',
+        },
+```
+
+And in `resources/js/lang/es.ts`:
+
+```ts
+        nav: {
+            profile: 'Perfil',
+            security: 'Seguridad',
+            appearance: 'Apariencia',
+            language: 'Idioma',
+            apiTokens: 'Tokens API',
+        },
+```
+
+```ts
+        apiTokens: {
+            title: 'Tokens API',
+            pageTitle: 'Ajustes de tokens API',
+            description:
+                'Crea tokens para permitir que los agentes de IA se conecten a esta instancia de Biglins a través del servidor MCP.',
+            namePlaceholder: 'Nombre del token (ej. "agente-1")',
+            create: 'Crear token',
+            empty: 'No hay tokens API todavía.',
+            createdAt: 'Creado {time}',
+            lastUsedAt: 'Último uso {time}',
+            neverUsed: 'Nunca usado',
+            revoke: 'Revocar',
+            confirmRevoke: '¿Revocar este token? Cualquier agente que lo use perderá el acceso de inmediato.',
+            newTokenTitle: 'Copia tu nuevo token ahora',
+            newTokenDescription:
+                'Se mostrará solo esta vez. Guárdalo en un lugar seguro: no podrá recuperarse después.',
+            copy: 'Copiar',
+            copied: '¡Copiado!',
+        },
+```
+
+(Use each file's existing indentation/quote style — read the surrounding `settings` block before editing to match it exactly.)
+
+- [ ] **Step 3: Add the sidebar nav entry**
+
+In `resources/js/layouts/settings/Layout.vue`, add the import `import { index as editApiTokens } from '@/routes/api-tokens';` (adjust the import path to whatever Wayfinder generated in Step 1) and append to `sidebarNavItems`:
+
+```ts
+    {
+        title: t('settings.nav.apiTokens'),
+        href: editApiTokens(),
+    },
+```
+
+- [ ] **Step 4: Write the page**
+
+Create `resources/js/pages/settings/ApiTokens.vue`:
+
+```vue
+<script setup lang="ts">
+import { router, setLayoutProps, usePage } from '@inertiajs/vue3';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import ApiTokenController from '@/actions/App/Http/Controllers/Settings/ApiTokenController';
+import Heading from '@/components/Heading.vue';
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { index } from '@/routes/api-tokens';
+import type { BreadcrumbItem } from '@/types';
+
+type ApiToken = {
+    id: number;
+    name: string;
+    created_at_diff: string | null;
+    last_used_at_diff: string | null;
+};
+
+const props = defineProps<{ tokens: ApiToken[] }>();
+
+const { t } = useI18n();
+
+setLayoutProps({
+    breadcrumbs: [
+        { title: t('settings.apiTokens.pageTitle'), href: index() },
+    ] satisfies BreadcrumbItem[],
+});
+
+const name = ref('');
+const nameError = ref<string | undefined>(undefined);
+const creating = ref(false);
+const copied = ref(false);
+
+const page = usePage<{ props: { newApiToken?: string } }>();
+const newToken = ref(page.props.newApiToken as string | undefined);
+
+function createToken(): void {
+    creating.value = true;
+    nameError.value = undefined;
+
+    router.post(
+        ApiTokenController.store.url(),
+        { name: name.value },
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                name.value = '';
+                newToken.value = usePage().props.newApiToken as
+                    | string
+                    | undefined;
+            },
+            onError: (errors) => {
+                nameError.value = errors.name;
+            },
+            onFinish: () => {
+                creating.value = false;
+            },
+        },
+    );
+}
+
+function revokeToken(tokenId: number): void {
+    if (!confirm(t('settings.apiTokens.confirmRevoke'))) {
+        return;
+    }
+
+    router.delete(ApiTokenController.destroy.url(tokenId), {
+        preserveScroll: true,
+    });
+}
+
+async function copyToken(): Promise<void> {
+    if (!newToken.value) {
+        return;
+    }
+
+    await navigator.clipboard.writeText(newToken.value);
+    copied.value = true;
+    setTimeout(() => {
+        copied.value = false;
+    }, 2000);
+}
+</script>
+
+<template>
+    <h1 class="sr-only">{{ t('settings.apiTokens.pageTitle') }}</h1>
+
+    <div class="space-y-6">
+        <Heading
+            variant="small"
+            :title="t('settings.apiTokens.title')"
+            :description="t('settings.apiTokens.description')"
+        />
+
+        <div
+            v-if="newToken"
+            class="space-y-2 rounded-md border border-amber-400 bg-amber-50 p-4 dark:bg-amber-950"
+        >
+            <p class="font-medium">
+                {{ t('settings.apiTokens.newTokenTitle') }}
+            </p>
+            <p class="text-muted-foreground text-sm">
+                {{ t('settings.apiTokens.newTokenDescription') }}
+            </p>
+            <div class="flex items-center gap-2">
+                <code
+                    class="bg-muted flex-1 overflow-x-auto rounded p-2 text-sm"
+                    >{{ newToken }}</code
+                >
+                <Button variant="outline" size="sm" @click="copyToken">
+                    {{
+                        copied
+                            ? t('settings.apiTokens.copied')
+                            : t('settings.apiTokens.copy')
+                    }}
+                </Button>
+            </div>
+        </div>
+
+        <form
+            class="flex items-end gap-4"
+            @submit.prevent="createToken"
+        >
+            <div class="grid flex-1 gap-2">
+                <Label for="token-name">{{
+                    t('settings.apiTokens.namePlaceholder')
+                }}</Label>
+                <Input id="token-name" v-model="name" required />
+                <InputError :message="nameError" />
+            </div>
+            <Button :disabled="creating" type="submit">
+                {{ t('settings.apiTokens.create') }}
+            </Button>
+        </form>
+
+        <p
+            v-if="props.tokens.length === 0"
+            class="text-muted-foreground text-sm"
+        >
+            {{ t('settings.apiTokens.empty') }}
+        </p>
+
+        <ul v-else class="divide-y">
+            <li
+                v-for="token in props.tokens"
+                :key="token.id"
+                class="flex items-center justify-between py-3"
+            >
+                <div>
+                    <p class="font-medium">{{ token.name }}</p>
+                    <p class="text-muted-foreground text-sm">
+                        {{
+                            t('settings.apiTokens.createdAt', {
+                                time: token.created_at_diff,
+                            })
+                        }}
+                        ·
+                        {{
+                            token.last_used_at_diff
+                                ? t('settings.apiTokens.lastUsedAt', {
+                                      time: token.last_used_at_diff,
+                                  })
+                                : t('settings.apiTokens.neverUsed')
+                        }}
+                    </p>
+                </div>
+                <Button
+                    variant="destructive"
+                    size="sm"
+                    @click="revokeToken(token.id)"
+                >
+                    {{ t('settings.apiTokens.revoke') }}
+                </Button>
+            </li>
+        </ul>
+    </div>
+</template>
+```
+
+Before finalizing, check `resources/js/components/ui/input` exists (it's used by other settings forms, e.g. `Profile.vue`) and that `Inertia::flash()` values surface on `page.props` the same way `toast` already does elsewhere in the app (see `resources/js/lib/flashToast.ts`) — follow that existing mechanism rather than introducing a new one if it differs from the `usePage().props.newApiToken` access used above.
+
+- [ ] **Step 5: Manual verification**
+
+Start the dev server (`composer run dev` or ask the user to, per project convention) and, logged in:
+1. Visit Settings — confirm "API Tokens" appears in the sidebar nav.
+2. Create a token — confirm the plaintext value is shown once, the list updates, and reloading the page no longer shows the plaintext value.
+3. Revoke the token — confirm it disappears from the list.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add resources/js
+git commit -m "feat: add Settings > API Tokens page"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §1 (dual transport) → Tasks 2, 10. §2 (Sanctum auth + token UI) → Tasks 10, 11, 12. §3 (`CurrentCompany::runningAs`) → Task 1, consumed by Tasks 3, 5, 7. §4 (all 8 tools) → Tasks 2–9. §5 (testing) → a test file per task; the web-transport 401/200 smoke test is Task 10's `WebTransportAuthTest`.
+- **Type consistency:** every write tool's `handle()` follows the same `validate company_id → findOrFail → runningAs → validate business rules → Response::structured` shape; every read/list tool follows the same `validate company_id → query → Response::structured` shape. `CurrentCompany::runningAs(Company $company, Closure $callback): mixed` (Task 1) is the exact signature every later task calls.

--- a/docs/superpowers/specs/2026-08-17-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-08-17-mcp-server-design.md
@@ -1,0 +1,91 @@
+# Server MCP — Design
+
+Data: 2026-08-17
+
+Issue: [#24](https://github.com/simonecosci/biglins/issues/24), sub-issue: [#34](https://github.com/simonecosci/biglins/issues/34) [#35](https://github.com/simonecosci/biglins/issues/35) [#36](https://github.com/simonecosci/biglins/issues/36) [#37](https://github.com/simonecosci/biglins/issues/37) [#38](https://github.com/simonecosci/biglins/issues/38)
+
+## Obiettivo
+
+Esporre un server MCP (protocollo, tramite il package ufficiale `laravel/mcp`, non un server Node.js separato) che permetta ad agenti AI di operare su Biglins: creare clienti, creare preventivi, creare fatture, inviarli via email. Biglins è un'app desktop NativePHP (singolo utente, singola macchina, sqlite locale), quindi il server gira come processo locale invocato dall'agente, senza esposizione di rete né autenticazione.
+
+## 1. Trasporto e registrazione
+
+- `laravel/mcp` è già presente in `composer.lock` come dipendenza di sviluppo (transitiva, tramite `laravel/boost`). Va promosso a dipendenza reale in `composer.json` (`require`, non `require-dev`), perché il server deve funzionare anche in produzione (build distribuita dell'app desktop).
+- Nuovo `App\Mcp\Servers\BiglinsServer` (namespace di default del package: `App\Mcp\Servers`), registrato in `routes/ai.php` con `Mcp::local('biglins', BiglinsServer::class)`.
+- L'agente si collega spawnando `php artisan mcp:start biglins` come sottoprocesso (stdio). Nessuna rotta HTTP, nessun token: chi può eseguire l'artisan locale ha già accesso pieno al DB sqlite dell'app.
+
+## 2. Scoping per company fuori dal contesto HTTP
+
+`CurrentCompany::resolve()` legge `session('current_company_id')`, ma il processo MCP non ha una sessione HTTP. Ogni tool riceve quindi un parametro esplicito `company_id`, validato con `Rule::exists('companies', 'id')`.
+
+Per riusare senza duplicazioni le regole di validazione e lo scoping già scritti nei controller/FormRequest (che chiamano tutti `CurrentCompany::resolve()`), `App\Support\CurrentCompany` guadagna un override temporaneo:
+
+```php
+class CurrentCompany
+{
+    private static ?Company $override = null;
+
+    public static function runningAs(Company $company, Closure $callback): mixed
+    {
+        $previous = self::$override;
+        self::$override = $company;
+
+        try {
+            return $callback();
+        } finally {
+            self::$override = $previous;
+        }
+    }
+
+    public static function resolve(): ?Company
+    {
+        if (self::$override !== null) {
+            return self::$override;
+        }
+
+        // ... logica esistente basata su sessione ...
+    }
+}
+```
+
+Ogni tool di scrittura: risolve la `Company` dal `company_id` in input, poi esegue la propria logica dentro `CurrentCompany::runningAs($company, fn () => ...)`. Dentro la closure, le regole di validazione business (es. `customer_id` deve appartenere alla company) si ottengono istanziando la `FormRequest` esistente e chiamandone `rules()`:
+
+```php
+Validator::make($input, (new StoreInvoiceRequest())->rules())->validate();
+```
+
+Questo evita di riscrivere le regole di unicità/appartenenza già espresse nei FormRequest. Gli errori di validazione diventano `Response::error($validator->errors()->first())` nel tool (il protocollo MCP non ha un formato 422 strutturato come le request HTTP).
+
+Il `runningAs` è annidato per singola chiamata di tool: il server MCP locale processa le richieste in sequenza all'interno dello stesso processo PHP, quindi non serve alcuna sincronizzazione — l'override è sempre ripristinato a `null` (o al valore precedente) subito dopo la `finally`.
+
+## 3. Tool
+
+Namespace `App\Mcp\Tools`. Ogni tool estende `Laravel\Mcp\Server\Tool`, con `schema()` per la struttura (tipi/required via `Illuminate\JsonSchema`) e `handle()` per la logica.
+
+**Clienti**
+- `list_customers(company_id, search?)` — mirror di `CustomerController@index`, senza paginazione (l'agente non naviga pagine), fino a un limite ragionevole (es. 50 risultati) con nota se troncato.
+- `create_customer(company_id, name, address?, zip?, city?, country_id?, state?, email?, web?, phone?, nif?)` — valida con `StoreCustomerRequest::rules()`, `Customer::create()`.
+
+**Preventivi**
+- `list_estimations(company_id)` — mirror di `EstimationController@index`.
+- `create_estimation(company_id, customer_id, estimation_date, expiration_date, language, body?, rows[])` — valida con `StoreEstimationRequest::rules()`, stessa logica di creazione (`Estimation::create()` + `rows()->createMany()`) di `EstimationController@store`.
+
+**Fatture**
+- `list_invoices(company_id)` — mirror di `InvoiceController@index`.
+- `create_invoice(company_id, type?, invoice_date, customer_id, note?, language, rows[])` — valida con `StoreInvoiceRequest::rules()`, stessa logica di `InvoiceController@store` (transazione, `normalizeRowPrice` per le note di credito).
+
+**Invio email**
+- `send_invoice_email(company_id, invoice_id, to, subject, message)` — valida con `SendInvoiceRequest::rules()`, stessa logica di `InvoiceController@send` (verifica che la fattura appartenga alla company, invia `InvoiceMail`, aggiorna `sent_at`/`sent_to`).
+- `send_estimation_email(company_id, estimation_id, to, subject, message)` — equivalente per preventivi (`EstimationMail`, `EstimationController@send`).
+
+Ogni tool che riceve un id di risorsa (`invoice_id`, `estimation_id`, `customer_id` nelle rows) verifica l'appartenenza alla company risolta prima di procedere, con lo stesso pattern 403-style già usato da `ScopesToCurrentCompany` (qui: `Response::error(...)` invece di `abort(403)`).
+
+## 4. Testing (Pest, feature)
+
+- Un test per tool: creazione con dati validi verifica lo stato DB; dati invalidi verificano `Response::error`; risorse (`customer_id`, `invoice_id`, ...) di un'altra company vengono rifiutate.
+- `send_invoice_email`/`send_estimation_email`: `Mail::fake()` + assert `Mail::assertSent(...)`, verifica aggiornamento `sent_at`/`sent_to`.
+- `CurrentCompanyTest` (esteso): `runningAs()` sovrascrive `resolve()` per la durata della closure e ripristina il valore precedente al termine, anche in caso di eccezione.
+
+## Note
+
+Nessuna migrazione necessaria: tutti i tool operano sulle tabelle esistenti. Nessuna gestione di autenticazione/autorizzazione oltre allo scoping per company: coerentemente con il resto dell'app (vedi `docs/superpowers/specs/2026-08-13-company-context-design.md`), non esiste un confine di tenancy per utente, quindi il server MCP locale ha accesso a tutte le company presenti nel DB — lo scoping serve a evitare scritture cross-company accidentali, non a limitare la visibilità.

--- a/docs/superpowers/specs/2026-08-17-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-08-17-mcp-server-design.md
@@ -2,19 +2,41 @@
 
 Data: 2026-08-17
 
-Issue: [#24](https://github.com/simonecosci/biglins/issues/24), sub-issue: [#34](https://github.com/simonecosci/biglins/issues/34) [#35](https://github.com/simonecosci/biglins/issues/35) [#36](https://github.com/simonecosci/biglins/issues/36) [#37](https://github.com/simonecosci/biglins/issues/37) [#38](https://github.com/simonecosci/biglins/issues/38)
+Issue: [#24](https://github.com/simonecosci/biglins/issues/24), sub-issue: [#34](https://github.com/simonecosci/biglins/issues/34) [#39](https://github.com/simonecosci/biglins/issues/39) [#35](https://github.com/simonecosci/biglins/issues/35) [#36](https://github.com/simonecosci/biglins/issues/36) [#37](https://github.com/simonecosci/biglins/issues/37) [#38](https://github.com/simonecosci/biglins/issues/38)
 
 ## Obiettivo
 
-Esporre un server MCP (protocollo, tramite il package ufficiale `laravel/mcp`, non un server Node.js separato) che permetta ad agenti AI di operare su Biglins: creare clienti, creare preventivi, creare fatture, inviarli via email. Biglins è un'app desktop NativePHP (singolo utente, singola macchina, sqlite locale), quindi il server gira come processo locale invocato dall'agente, senza esposizione di rete né autenticazione.
+Esporre un server MCP (protocollo, tramite il package ufficiale `laravel/mcp`, non un server Node.js separato) che permetta ad agenti AI di operare su Biglins: creare clienti, creare preventivi, creare fatture, inviarli via email. Biglins si distribuisce in due modalità (vedi `docs/superpowers/specs/2026-08-15-nativephp-desktop-design.md` e `docs/superpowers/specs/2026-08-15-https-support-design.md`): app desktop NativePHP (singolo utente, singola macchina, sqlite locale) e immagine Docker (può essere esposta su internet, con HTTPS, autenticazione Fortify multi-utente). Il server MCP deve funzionare in entrambe, con requisiti di trasporto/sicurezza diversi.
 
-## 1. Trasporto e registrazione
+## 1. Trasporto e registrazione (doppio transport)
 
-- `laravel/mcp` è già presente in `composer.lock` come dipendenza di sviluppo (transitiva, tramite `laravel/boost`). Va promosso a dipendenza reale in `composer.json` (`require`, non `require-dev`), perché il server deve funzionare anche in produzione (build distribuita dell'app desktop).
-- Nuovo `App\Mcp\Servers\BiglinsServer` (namespace di default del package: `App\Mcp\Servers`), registrato in `routes/ai.php` con `Mcp::local('biglins', BiglinsServer::class)`.
-- L'agente si collega spawnando `php artisan mcp:start biglins` come sottoprocesso (stdio). Nessuna rotta HTTP, nessun token: chi può eseguire l'artisan locale ha già accesso pieno al DB sqlite dell'app.
+`App\Mcp\Servers\BiglinsServer` e i tool sono condivisi tra le due modalità; cambia solo come ci si collega:
 
-## 2. Scoping per company fuori dal contesto HTTP
+- **Desktop (NativePHP)**: trasporto locale/stdio. `Mcp::local('biglins', BiglinsServer::class)` in `routes/ai.php`. L'agente si collega spawnando `php artisan mcp:start biglins` come sottoprocesso sulla stessa macchina. Nessuna rotta HTTP, nessun token: chi può eseguire l'artisan locale ha già accesso pieno al DB sqlite dell'app.
+- **Docker/web**: trasporto HTTP. `Mcp::web('/mcp/biglins', BiglinsServer::class)->middleware('auth:sanctum')` nello stesso file. Essendo potenzialmente esposto su internet, richiede autenticazione (§ 2).
+
+`laravel/mcp` è già presente in `composer.lock` come dipendenza di sviluppo (transitiva, tramite `laravel/boost`). Va promosso a dipendenza reale in `composer.json` (`require`, non `require-dev`), perché il server deve funzionare anche in produzione (sia build desktop che immagine Docker).
+
+## 2. Autenticazione del trasporto web — Sanctum
+
+Il supporto OAuth nativo di `laravel/mcp` (`Mcp::oauthRoutes()`) richiede `laravel/passport` (server OAuth2 completo): dipendenza pesante, pensata per flussi tipo "Connect your account" da piattaforme hosted con consent screen. Sproporzionata per questa app. Si usa invece **Laravel Sanctum**, già lo standard Laravel per token API personali:
+
+- Nuova dipendenza `laravel/sanctum` (`require`).
+- Migration standard di Sanctum (`personal_access_tokens`), trait `HasApiTokens` su `App\Models\User`.
+- Rotta web protetta con `->middleware('auth:sanctum')`: l'agente manda `Authorization: Bearer <token>`.
+- Nessun impatto sullo scoping per company (§ 3): anche in modalità web, come nel resto dell'app, non esiste un confine di tenancy per utente — un token valido di un qualsiasi utente autenticato dà accesso a tutte le company nel DB, esattamente come già succede oggi per un utente loggato via browser.
+
+### Gestione token — Settings > API Tokens
+
+Nuova pagina Inertia `settings/ApiTokens.vue`, stesso pattern della gestione passkey già esistente in `settings/Security.vue`:
+
+- `App\Http\Controllers\Settings\ApiTokenController@index`: lista i token dell'utente corrente (`name`, `created_at`, `last_used_at`), nessun campo segreto esposto dopo la creazione.
+- `@store`: crea un token (`$request->user()->createToken($name)`), la pagina mostra il valore in chiaro **una sola volta** (pattern standard Sanctum), poi solo l'hash è recuperabile.
+- `@destroy`: revoca (elimina) un token.
+- Nuove rotte in `routes/settings.php`, gruppo `auth`/`verified`, stesso pattern delle rotte password/passkey esistenti.
+- Voce di navigazione nel menu Settings esistente, accanto a Security/Language/Appearance.
+
+## 3. Scoping per company fuori dal contesto HTTP
 
 `CurrentCompany::resolve()` legge `session('current_company_id')`, ma il processo MCP non ha una sessione HTTP. Ogni tool riceve quindi un parametro esplicito `company_id`, validato con `Rule::exists('companies', 'id')`.
 
@@ -58,7 +80,7 @@ Questo evita di riscrivere le regole di unicità/appartenenza già espresse nei 
 
 Il `runningAs` è annidato per singola chiamata di tool: il server MCP locale processa le richieste in sequenza all'interno dello stesso processo PHP, quindi non serve alcuna sincronizzazione — l'override è sempre ripristinato a `null` (o al valore precedente) subito dopo la `finally`.
 
-## 3. Tool
+## 4. Tool
 
 Namespace `App\Mcp\Tools`. Ogni tool estende `Laravel\Mcp\Server\Tool`, con `schema()` per la struttura (tipi/required via `Illuminate\JsonSchema`) e `handle()` per la logica.
 
@@ -80,12 +102,14 @@ Namespace `App\Mcp\Tools`. Ogni tool estende `Laravel\Mcp\Server\Tool`, con `sch
 
 Ogni tool che riceve un id di risorsa (`invoice_id`, `estimation_id`, `customer_id` nelle rows) verifica l'appartenenza alla company risolta prima di procedere, con lo stesso pattern 403-style già usato da `ScopesToCurrentCompany` (qui: `Response::error(...)` invece di `abort(403)`).
 
-## 4. Testing (Pest, feature)
+## 5. Testing (Pest, feature)
 
-- Un test per tool: creazione con dati validi verifica lo stato DB; dati invalidi verificano `Response::error`; risorse (`customer_id`, `invoice_id`, ...) di un'altra company vengono rifiutate.
+- Un test per tool: creazione con dati validi verifica lo stato DB; dati invalidi verificano `Response::error`; risorse (`customer_id`, `invoice_id`, ...) di un'altra company vengono rifiutate. Ogni test esercita i tool direttamente (non serve avviare un vero processo `mcp:start`), seguendo l'helper di test fornito da `laravel/mcp` (es. `Server::actingAs(...)` / chiamata diretta al tool).
 - `send_invoice_email`/`send_estimation_email`: `Mail::fake()` + assert `Mail::assertSent(...)`, verifica aggiornamento `sent_at`/`sent_to`.
 - `CurrentCompanyTest` (esteso): `runningAs()` sovrascrive `resolve()` per la durata della closure e ripristina il valore precedente al termine, anche in caso di eccezione.
+- `ApiTokenTest` (nuovo, feature HTTP standard): creazione/elenco/revoca token da Settings; il token in chiaro è presente solo nella risposta di creazione.
+- Un test HTTP che chiama la rotta `Mcp::web()` senza token → 401; con token Sanctum valido → risposta MCP valida (smoke test del wiring auth, non re-testa la logica dei singoli tool già coperta sopra).
 
 ## Note
 
-Nessuna migrazione necessaria: tutti i tool operano sulle tabelle esistenti. Nessuna gestione di autenticazione/autorizzazione oltre allo scoping per company: coerentemente con il resto dell'app (vedi `docs/superpowers/specs/2026-08-13-company-context-design.md`), non esiste un confine di tenancy per utente, quindi il server MCP locale ha accesso a tutte le company presenti nel DB — lo scoping serve a evitare scritture cross-company accidentali, non a limitare la visibilità.
+Migrazione necessaria: quella standard di Sanctum (`personal_access_tokens`), pubblicata da `php artisan install:api` o `vendor:publish --tag=sanctum-migrations`. Nessun'altra migrazione: i tool MCP operano sulle tabelle esistenti. Lo scoping per company (§ 3) evita scritture cross-company *accidentali*, non limita la visibilità: coerentemente con il resto dell'app (vedi `docs/superpowers/specs/2026-08-13-company-context-design.md`), non esiste un confine di tenancy per utente — sia un processo locale (desktop) sia un token Sanctum valido (web) danno accesso a tutte le company presenti nel DB.

--- a/resources/js/lang/en.ts
+++ b/resources/js/lang/en.ts
@@ -37,6 +37,7 @@ const messages = {
             security: 'Security',
             appearance: 'Appearance',
             language: 'Language',
+            apiTokens: 'API Tokens',
         },
         appearance: {
             title: 'Appearance settings',
@@ -154,6 +155,26 @@ const messages = {
                 registerButton: 'Register passkey',
                 registeringButton: 'Registering...',
             },
+        },
+        apiTokens: {
+            title: 'API tokens',
+            pageTitle: 'API token settings',
+            description:
+                'Create tokens to let AI agents connect to this Biglins instance over the MCP server.',
+            namePlaceholder: 'Token name (e.g. "agent-1")',
+            create: 'Create token',
+            empty: 'No API tokens yet.',
+            createdAt: 'Created {time}',
+            lastUsedAt: 'Last used {time}',
+            neverUsed: 'Never used',
+            revoke: 'Revoke',
+            confirmRevoke:
+                'Revoke this token? Any agent using it will lose access immediately.',
+            newTokenTitle: 'Copy your new token now',
+            newTokenDescription:
+                "This is the only time it will be shown. Store it somewhere safe — it won't be recoverable afterwards.",
+            copy: 'Copy',
+            copied: 'Copied!',
         },
     },
     passwordInput: {

--- a/resources/js/lang/es.ts
+++ b/resources/js/lang/es.ts
@@ -39,6 +39,7 @@ const messages: MessageSchema = {
             security: 'Seguridad',
             appearance: 'Apariencia',
             language: 'Idioma',
+            apiTokens: 'Tokens API',
         },
         appearance: {
             title: 'Configuración de apariencia',
@@ -167,6 +168,26 @@ const messages: MessageSchema = {
                 registerButton: 'Registrar passkey',
                 registeringButton: 'Registrando...',
             },
+        },
+        apiTokens: {
+            title: 'Tokens API',
+            pageTitle: 'Ajustes de tokens API',
+            description:
+                'Crea tokens para permitir que los agentes de IA se conecten a esta instancia de Biglins a través del servidor MCP.',
+            namePlaceholder: 'Nombre del token (ej. "agente-1")',
+            create: 'Crear token',
+            empty: 'No hay tokens API todavía.',
+            createdAt: 'Creado {time}',
+            lastUsedAt: 'Último uso {time}',
+            neverUsed: 'Nunca usado',
+            revoke: 'Revocar',
+            confirmRevoke:
+                '¿Revocar este token? Cualquier agente que lo use perderá el acceso de inmediato.',
+            newTokenTitle: 'Copia tu nuevo token ahora',
+            newTokenDescription:
+                'Se mostrará solo esta vez. Guárdalo en un lugar seguro: no podrá recuperarse después.',
+            copy: 'Copiar',
+            copied: '¡Copiado!',
         },
     },
     passwordInput: {

--- a/resources/js/lang/it.ts
+++ b/resources/js/lang/it.ts
@@ -39,6 +39,7 @@ const messages: MessageSchema = {
             security: 'Sicurezza',
             appearance: 'Aspetto',
             language: 'Lingua',
+            apiTokens: 'Token API',
         },
         appearance: {
             title: 'Impostazioni aspetto',
@@ -162,6 +163,26 @@ const messages: MessageSchema = {
                 registerButton: 'Registra passkey',
                 registeringButton: 'Registrazione in corso...',
             },
+        },
+        apiTokens: {
+            title: 'Token API',
+            pageTitle: 'Impostazioni token API',
+            description:
+                'Crea token per permettere agli agenti AI di collegarsi a questa istanza di Biglins tramite il server MCP.',
+            namePlaceholder: 'Nome del token (es. "agente-1")',
+            create: 'Crea token',
+            empty: 'Nessun token API.',
+            createdAt: 'Creato {time}',
+            lastUsedAt: 'Ultimo utilizzo {time}',
+            neverUsed: 'Mai utilizzato',
+            revoke: 'Revoca',
+            confirmRevoke:
+                "Revocare questo token? Ogni agente che lo usa perderà l'accesso immediatamente.",
+            newTokenTitle: 'Copia subito il tuo nuovo token',
+            newTokenDescription:
+                'Verrà mostrato solo questa volta. Conservalo in un posto sicuro: non potrà essere recuperato in seguito.',
+            copy: 'Copia',
+            copied: 'Copiato!',
         },
     },
     passwordInput: {

--- a/resources/js/layouts/settings/Layout.vue
+++ b/resources/js/layouts/settings/Layout.vue
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useCurrentUrl } from '@/composables/useCurrentUrl';
 import { toUrl } from '@/lib/utils';
+import { index as editApiTokens } from '@/routes/api-tokens';
 import { edit as editAppearance } from '@/routes/appearance';
 import { edit as editLanguage } from '@/routes/language';
 import { edit as editProfile } from '@/routes/profile';
@@ -31,6 +32,10 @@ const sidebarNavItems = computed<NavItem[]>(() => [
     {
         title: t('settings.nav.language'),
         href: editLanguage(),
+    },
+    {
+        title: t('settings.nav.apiTokens'),
+        href: editApiTokens(),
     },
 ]);
 

--- a/resources/js/pages/settings/ApiTokens.vue
+++ b/resources/js/pages/settings/ApiTokens.vue
@@ -8,6 +8,7 @@ import InputError from '@/components/InputError.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { confirmDialog } from '@/lib/confirmDialog';
 import { index } from '@/routes/api-tokens';
 import type { BreadcrumbItem } from '@/types';
 
@@ -73,8 +74,8 @@ function createToken(): void {
     );
 }
 
-function revokeToken(tokenId: number): void {
-    if (!confirm(t('settings.apiTokens.confirmRevoke'))) {
+async function revokeToken(tokenId: number): Promise<void> {
+    if (!(await confirmDialog(t('settings.apiTokens.confirmRevoke')))) {
         return;
     }
 

--- a/resources/js/pages/settings/ApiTokens.vue
+++ b/resources/js/pages/settings/ApiTokens.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { Head, router, setLayoutProps } from '@inertiajs/vue3';
+import { onMounted, onUnmounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import ApiTokenController from '@/actions/App/Http/Controllers/Settings/ApiTokenController';
+import Heading from '@/components/Heading.vue';
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { index } from '@/routes/api-tokens';
+import type { BreadcrumbItem } from '@/types';
+
+type ApiToken = {
+    id: number;
+    name: string;
+    created_at_diff: string | null;
+    last_used_at_diff: string | null;
+};
+
+const props = defineProps<{ tokens: ApiToken[] }>();
+
+const { t } = useI18n();
+
+setLayoutProps({
+    breadcrumbs: [
+        { title: t('settings.apiTokens.pageTitle'), href: index() },
+    ] satisfies BreadcrumbItem[],
+});
+
+const name = ref('');
+const nameError = ref<string | undefined>(undefined);
+const creating = ref(false);
+const copied = ref(false);
+
+const newToken = ref<string | undefined>(undefined);
+let unsubscribe: (() => void) | undefined;
+
+onMounted(() => {
+    unsubscribe = router.on('flash', (event) => {
+        const flash = (event as CustomEvent).detail?.flash as
+            { newApiToken?: string } | undefined;
+
+        if (flash?.newApiToken) {
+            newToken.value = flash.newApiToken;
+        }
+    });
+});
+
+onUnmounted(() => {
+    unsubscribe?.();
+});
+
+function createToken(): void {
+    creating.value = true;
+    nameError.value = undefined;
+
+    router.post(
+        ApiTokenController.store.url(),
+        { name: name.value },
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                name.value = '';
+            },
+            onError: (errors) => {
+                nameError.value = errors.name;
+            },
+            onFinish: () => {
+                creating.value = false;
+            },
+        },
+    );
+}
+
+function revokeToken(tokenId: number): void {
+    if (!confirm(t('settings.apiTokens.confirmRevoke'))) {
+        return;
+    }
+
+    router.delete(ApiTokenController.destroy.url(tokenId), {
+        preserveScroll: true,
+    });
+}
+
+async function copyToken(): Promise<void> {
+    if (!newToken.value) {
+        return;
+    }
+
+    await navigator.clipboard.writeText(newToken.value);
+    copied.value = true;
+    setTimeout(() => {
+        copied.value = false;
+    }, 2000);
+}
+</script>
+
+<template>
+    <Head :title="t('settings.apiTokens.pageTitle')" />
+
+    <h1 class="sr-only">{{ t('settings.apiTokens.pageTitle') }}</h1>
+
+    <div class="space-y-6">
+        <Heading
+            variant="small"
+            :title="t('settings.apiTokens.title')"
+            :description="t('settings.apiTokens.description')"
+        />
+
+        <div
+            v-if="newToken"
+            class="space-y-2 rounded-md border border-amber-400 bg-amber-50 p-4 dark:bg-amber-950"
+        >
+            <p class="font-medium">
+                {{ t('settings.apiTokens.newTokenTitle') }}
+            </p>
+            <p class="text-sm text-muted-foreground">
+                {{ t('settings.apiTokens.newTokenDescription') }}
+            </p>
+            <div class="flex items-center gap-2">
+                <code
+                    class="flex-1 overflow-x-auto rounded bg-muted p-2 text-sm"
+                    >{{ newToken }}</code
+                >
+                <Button variant="outline" size="sm" @click="copyToken">
+                    {{
+                        copied
+                            ? t('settings.apiTokens.copied')
+                            : t('settings.apiTokens.copy')
+                    }}
+                </Button>
+            </div>
+        </div>
+
+        <form class="flex items-end gap-4" @submit.prevent="createToken">
+            <div class="grid flex-1 gap-2">
+                <Label for="token-name">{{
+                    t('settings.apiTokens.namePlaceholder')
+                }}</Label>
+                <Input id="token-name" v-model="name" required />
+                <InputError :message="nameError" />
+            </div>
+            <Button :disabled="creating" type="submit">
+                {{ t('settings.apiTokens.create') }}
+            </Button>
+        </form>
+
+        <p
+            v-if="props.tokens.length === 0"
+            class="text-sm text-muted-foreground"
+        >
+            {{ t('settings.apiTokens.empty') }}
+        </p>
+
+        <ul v-else class="divide-y">
+            <li
+                v-for="token in props.tokens"
+                :key="token.id"
+                class="flex items-center justify-between py-3"
+            >
+                <div>
+                    <p class="font-medium">{{ token.name }}</p>
+                    <p class="text-sm text-muted-foreground">
+                        {{
+                            t('settings.apiTokens.createdAt', {
+                                time: token.created_at_diff,
+                            })
+                        }}
+                        ·
+                        {{
+                            token.last_used_at_diff
+                                ? t('settings.apiTokens.lastUsedAt', {
+                                      time: token.last_used_at_diff,
+                                  })
+                                : t('settings.apiTokens.neverUsed')
+                        }}
+                    </p>
+                </div>
+                <Button
+                    variant="destructive"
+                    size="sm"
+                    @click="revokeToken(token.id)"
+                >
+                    {{ t('settings.apiTokens.revoke') }}
+                </Button>
+            </li>
+        </ul>
+    </div>
+</template>

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use Laravel\Mcp\Facades\Mcp;
+
+Mcp::local('biglins', BiglinsServer::class);

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -4,3 +4,5 @@ use App\Mcp\Servers\BiglinsServer;
 use Laravel\Mcp\Facades\Mcp;
 
 Mcp::local('biglins', BiglinsServer::class);
+
+Mcp::web('/mcp/biglins', BiglinsServer::class)->middleware('auth:sanctum');

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -5,4 +5,4 @@ use Laravel\Mcp\Facades\Mcp;
 
 Mcp::local('biglins', BiglinsServer::class);
 
-Mcp::web('/mcp/biglins', BiglinsServer::class)->middleware('auth:sanctum');
+Mcp::web('/mcp/biglins', BiglinsServer::class)->middleware(['throttle:60,1', 'auth:sanctum']);

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -5,4 +5,6 @@ use Laravel\Mcp\Facades\Mcp;
 
 Mcp::local('biglins', BiglinsServer::class);
 
-Mcp::web('/mcp/biglins', BiglinsServer::class)->middleware(['throttle:60,1', 'auth:sanctum']);
+Mcp::web('/mcp/biglins', BiglinsServer::class)->middleware(['throttle:60,1', 'auth:sanctum,api']);
+
+Mcp::oauthRoutes();

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/user', function (Request $request) {
+    return $request->user();
+})->middleware('auth:api');

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Settings\ApiTokenController;
 use App\Http\Controllers\Settings\LanguageController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\SecurityController;
@@ -26,6 +27,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::put('settings/password', [SecurityController::class, 'update'])
         ->middleware('throttle:6,1')
         ->name('user-password.update');
+
+    Route::get('settings/api-tokens', [ApiTokenController::class, 'index'])->name('api-tokens.index');
+    Route::post('settings/api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
+    Route::delete('settings/api-tokens/{token}', [ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
 
     Route::inertia('settings/appearance', 'settings/Appearance')->name('appearance.edit');
 });

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -30,7 +30,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('settings/api-tokens', [ApiTokenController::class, 'index'])->name('api-tokens.index');
     Route::post('settings/api-tokens', [ApiTokenController::class, 'store'])->name('api-tokens.store');
-    Route::delete('settings/api-tokens/{token}', [ApiTokenController::class, 'destroy'])->name('api-tokens.destroy');
+    Route::delete('settings/api-tokens/{token}', [ApiTokenController::class, 'destroy'])->name('api-tokens.destroy')->whereNumber('token');
 
     Route::inertia('settings/appearance', 'settings/Appearance')->name('appearance.edit');
 });

--- a/tests/Feature/CurrentCompanyTest.php
+++ b/tests/Feature/CurrentCompanyTest.php
@@ -77,3 +77,37 @@ test('guests are redirected to the login page when switching the current company
 
     $response->assertRedirect(route('login'));
 });
+
+test('runningAs overrides resolve for the duration of the closure', function () {
+    $sessionCompany = Company::factory()->create();
+    $overrideCompany = Company::factory()->create();
+    session(['current_company_id' => $sessionCompany->id]);
+
+    $resolvedDuring = CurrentCompany::runningAs($overrideCompany, fn () => CurrentCompany::resolve()?->id);
+
+    expect($resolvedDuring)->toBe($overrideCompany->id);
+    expect(CurrentCompany::resolve()->id)->toBe($sessionCompany->id);
+});
+
+test('runningAs restores the previous override when the closure throws', function () {
+    $company = Company::factory()->create();
+
+    expect(fn () => CurrentCompany::runningAs($company, function () {
+        throw new RuntimeException('boom');
+    }))->toThrow(RuntimeException::class);
+
+    expect(CurrentCompany::resolve())->not->toBe($company);
+});
+
+test('runningAs nests correctly, restoring the outer override on exit', function () {
+    $outer = Company::factory()->create();
+    $inner = Company::factory()->create();
+
+    $result = CurrentCompany::runningAs($outer, function () use ($inner) {
+        $duringInner = CurrentCompany::runningAs($inner, fn () => CurrentCompany::resolve()->id);
+
+        return [$duringInner, CurrentCompany::resolve()->id];
+    });
+
+    expect($result)->toBe([$inner->id, $outer->id]);
+});

--- a/tests/Feature/Mcp/CreateCustomerToolTest.php
+++ b/tests/Feature/Mcp/CreateCustomerToolTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\CreateCustomerTool;
+use App\Models\Company;
+use App\Models\Customer;
+
+test('create_customer creates a customer scoped to the given company', function () {
+    $company = Company::factory()->create();
+
+    $response = BiglinsServer::tool(CreateCustomerTool::class, [
+        'company_id' => $company->id,
+        'name' => 'Acme Corp',
+        'email' => 'billing@acme.test',
+    ]);
+
+    $response->assertOk();
+    $customer = Customer::query()->where('name', 'Acme Corp')->firstOrFail();
+    expect($customer->company_id)->toBe($company->id);
+    expect($customer->email)->toBe('billing@acme.test');
+});
+
+test('create_customer requires a name', function () {
+    $company = Company::factory()->create();
+
+    $response = BiglinsServer::tool(CreateCustomerTool::class, [
+        'company_id' => $company->id,
+        'name' => '',
+    ]);
+
+    $response->assertHasErrors();
+    expect(Customer::query()->where('company_id', $company->id)->exists())->toBeFalse();
+});
+
+test('create_customer rejects an invalid email', function () {
+    $company = Company::factory()->create();
+
+    $response = BiglinsServer::tool(CreateCustomerTool::class, [
+        'company_id' => $company->id,
+        'name' => 'Acme Corp',
+        'email' => 'not-an-email',
+    ]);
+
+    $response->assertHasErrors();
+});

--- a/tests/Feature/Mcp/CreateEstimationToolTest.php
+++ b/tests/Feature/Mcp/CreateEstimationToolTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\CreateEstimationTool;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Models\Estimation;
+
+test('create_estimation creates an estimation with rows scoped to the given company', function () {
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $response = BiglinsServer::tool(CreateEstimationTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'estimation_date' => '2026-08-17',
+        'expiration_date' => '2026-09-17',
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Consulting', 'quantity' => 2, 'price' => 100, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertOk();
+    $estimation = Estimation::query()->where('company_id', $company->id)->firstOrFail();
+    expect($estimation->customer_id)->toBe($customer->id);
+    expect($estimation->rows)->toHaveCount(1);
+    expect((float) $estimation->rows->first()->price)->toBe(100.0);
+});
+
+test('create_estimation rejects a customer_id belonging to another company', function () {
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(CreateEstimationTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'estimation_date' => '2026-08-17',
+        'expiration_date' => '2026-09-17',
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Consulting', 'quantity' => 1, 'price' => 100, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertHasErrors();
+    expect(Estimation::query()->where('company_id', $company->id)->exists())->toBeFalse();
+});
+
+test('create_estimation requires at least one row', function () {
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $response = BiglinsServer::tool(CreateEstimationTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'estimation_date' => '2026-08-17',
+        'expiration_date' => '2026-09-17',
+        'language' => 'en',
+        'rows' => [],
+    ]);
+
+    $response->assertHasErrors();
+});

--- a/tests/Feature/Mcp/CreateInvoiceToolTest.php
+++ b/tests/Feature/Mcp/CreateInvoiceToolTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\CreateInvoiceTool;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Models\Invoice;
+
+test('create_invoice creates an invoice with rows scoped to the given company', function () {
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $response = BiglinsServer::tool(CreateInvoiceTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'invoice_date' => '2026-08-17',
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Consulting', 'quantity' => 1, 'price' => 200, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertOk();
+    $invoice = Invoice::query()->where('company_id', $company->id)->firstOrFail();
+    expect($invoice->customer_id)->toBe($customer->id);
+    expect((float) $invoice->rows->first()->price)->toBe(200.0);
+});
+
+test('create_invoice negates row prices for a credit note', function () {
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+
+    $response = BiglinsServer::tool(CreateInvoiceTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'type' => 'credit_note',
+        'invoice_date' => '2026-08-17',
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Refund', 'quantity' => 1, 'price' => 50, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertOk();
+    $invoice = Invoice::query()->where('company_id', $company->id)->firstOrFail();
+    expect((float) $invoice->rows->first()->price)->toBe(-50.0);
+});
+
+test('create_invoice rejects a customer_id belonging to another company', function () {
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(CreateInvoiceTool::class, [
+        'company_id' => $company->id,
+        'customer_id' => $customer->id,
+        'invoice_date' => '2026-08-17',
+        'language' => 'en',
+        'rows' => [
+            ['description' => 'Consulting', 'quantity' => 1, 'price' => 100, 'vat_rate' => 22],
+        ],
+    ]);
+
+    $response->assertHasErrors();
+    expect(Invoice::query()->where('company_id', $company->id)->exists())->toBeFalse();
+});

--- a/tests/Feature/Mcp/ListCustomersToolTest.php
+++ b/tests/Feature/Mcp/ListCustomersToolTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\ListCustomersTool;
+use App\Models\Company;
+use App\Models\Customer;
+use Illuminate\Support\Str;
+
+test('list_customers returns customers scoped to the given company', function () {
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    Customer::factory()->count(2)->create(['company_id' => $company->id]);
+    Customer::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(ListCustomersTool::class, [
+        'company_id' => $company->id,
+    ]);
+
+    $response->assertOk();
+    $response->assertStructuredContent(fn ($json) => $json->count('customers', 2)->etc());
+});
+
+test('list_customers filters by the search term', function () {
+    $company = Company::factory()->create();
+    Customer::factory()->create(['company_id' => $company->id, 'name' => 'Acme Corp']);
+    Customer::factory()->create(['company_id' => $company->id, 'name' => 'Globex Inc']);
+
+    $response = BiglinsServer::tool(ListCustomersTool::class, [
+        'company_id' => $company->id,
+        'search' => 'Acme',
+    ]);
+
+    $response->assertOk();
+    $response->assertStructuredContent(fn ($json) => $json
+        ->count('customers', 1)
+        ->where('customers.0.name', 'Acme Corp')
+        ->etc());
+});
+
+test('list_customers rejects a company_id that does not exist', function () {
+    $response = BiglinsServer::tool(ListCustomersTool::class, [
+        'company_id' => (string) Str::uuid(),
+    ]);
+
+    $response->assertHasErrors();
+});

--- a/tests/Feature/Mcp/ListEstimationsToolTest.php
+++ b/tests/Feature/Mcp/ListEstimationsToolTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\ListEstimationsTool;
+use App\Models\Company;
+use App\Models\Estimation;
+use Illuminate\Support\Str;
+
+test('list_estimations returns estimations scoped to the given company', function () {
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    Estimation::factory()->count(2)->create(['company_id' => $company->id]);
+    Estimation::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(ListEstimationsTool::class, [
+        'company_id' => $company->id,
+    ]);
+
+    $response->assertOk();
+    $response->assertStructuredContent(fn ($json) => $json->count('estimations', 2)->etc());
+});
+
+test('list_estimations rejects a company_id that does not exist', function () {
+    $response = BiglinsServer::tool(ListEstimationsTool::class, [
+        'company_id' => (string) Str::uuid(),
+    ]);
+
+    $response->assertHasErrors();
+});

--- a/tests/Feature/Mcp/ListInvoicesToolTest.php
+++ b/tests/Feature/Mcp/ListInvoicesToolTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\ListInvoicesTool;
+use App\Models\Company;
+use App\Models\Invoice;
+use Illuminate\Support\Str;
+
+test('list_invoices returns invoices scoped to the given company', function () {
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    Invoice::factory()->count(2)->create(['company_id' => $company->id]);
+    Invoice::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(ListInvoicesTool::class, [
+        'company_id' => $company->id,
+    ]);
+
+    $response->assertOk();
+    $response->assertStructuredContent(fn ($json) => $json->count('invoices', 2)->etc());
+});
+
+test('list_invoices rejects a company_id that does not exist', function () {
+    $response = BiglinsServer::tool(ListInvoicesTool::class, [
+        'company_id' => (string) Str::uuid(),
+    ]);
+
+    $response->assertHasErrors();
+});

--- a/tests/Feature/Mcp/SendEstimationEmailToolTest.php
+++ b/tests/Feature/Mcp/SendEstimationEmailToolTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Mail\EstimationMail;
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\SendEstimationEmailTool;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Models\Estimation;
+use Illuminate\Support\Facades\Mail;
+
+test('send_estimation_email sends the estimation and records who it was sent to', function () {
+    Mail::fake();
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+    $estimation = Estimation::factory()->create(['company_id' => $company->id, 'customer_id' => $customer->id]);
+
+    $response = BiglinsServer::tool(SendEstimationEmailTool::class, [
+        'company_id' => $company->id,
+        'estimation_id' => $estimation->id,
+        'to' => 'client@example.test',
+        'subject' => 'Your estimation',
+        'message' => 'Please find your estimation attached.',
+    ]);
+
+    $response->assertOk();
+    Mail::assertSent(EstimationMail::class);
+    expect($estimation->fresh()->sent_to)->toBe('client@example.test');
+    expect($estimation->fresh()->sent_at)->not->toBeNull();
+});
+
+test('send_estimation_email rejects an estimation belonging to another company', function () {
+    Mail::fake();
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    $estimation = Estimation::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(SendEstimationEmailTool::class, [
+        'company_id' => $company->id,
+        'estimation_id' => $estimation->id,
+        'to' => 'client@example.test',
+        'subject' => 'Your estimation',
+        'message' => 'Please find your estimation attached.',
+    ]);
+
+    $response->assertHasErrors();
+    Mail::assertNotSent(EstimationMail::class);
+});

--- a/tests/Feature/Mcp/SendInvoiceEmailToolTest.php
+++ b/tests/Feature/Mcp/SendInvoiceEmailToolTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Mail\InvoiceMail;
+use App\Mcp\Servers\BiglinsServer;
+use App\Mcp\Tools\SendInvoiceEmailTool;
+use App\Models\Company;
+use App\Models\Customer;
+use App\Models\Invoice;
+use Illuminate\Support\Facades\Mail;
+
+test('send_invoice_email sends the invoice and records who it was sent to', function () {
+    Mail::fake();
+    $company = Company::factory()->create();
+    $customer = Customer::factory()->create(['company_id' => $company->id]);
+    $invoice = Invoice::factory()->create(['company_id' => $company->id, 'customer_id' => $customer->id]);
+
+    $response = BiglinsServer::tool(SendInvoiceEmailTool::class, [
+        'company_id' => $company->id,
+        'invoice_id' => $invoice->id,
+        'to' => 'client@example.test',
+        'subject' => 'Your invoice',
+        'message' => 'Please find your invoice attached.',
+    ]);
+
+    $response->assertOk();
+    Mail::assertSent(InvoiceMail::class);
+    expect($invoice->fresh()->sent_to)->toBe('client@example.test');
+    expect($invoice->fresh()->sent_at)->not->toBeNull();
+});
+
+test('send_invoice_email rejects an invoice belonging to another company', function () {
+    Mail::fake();
+    $company = Company::factory()->create();
+    $otherCompany = Company::factory()->create();
+    $invoice = Invoice::factory()->create(['company_id' => $otherCompany->id]);
+
+    $response = BiglinsServer::tool(SendInvoiceEmailTool::class, [
+        'company_id' => $company->id,
+        'invoice_id' => $invoice->id,
+        'to' => 'client@example.test',
+        'subject' => 'Your invoice',
+        'message' => 'Please find your invoice attached.',
+    ]);
+
+    $response->assertHasErrors();
+    Mail::assertNotSent(InvoiceMail::class);
+});
+
+test('send_invoice_email requires a valid recipient email', function () {
+    Mail::fake();
+    $company = Company::factory()->create();
+    $invoice = Invoice::factory()->create(['company_id' => $company->id]);
+
+    $response = BiglinsServer::tool(SendInvoiceEmailTool::class, [
+        'company_id' => $company->id,
+        'invoice_id' => $invoice->id,
+        'to' => 'not-an-email',
+        'subject' => 'Your invoice',
+        'message' => 'Please find your invoice attached.',
+    ]);
+
+    $response->assertHasErrors();
+    Mail::assertNotSent(InvoiceMail::class);
+});

--- a/tests/Feature/Mcp/WebTransportAuthTest.php
+++ b/tests/Feature/Mcp/WebTransportAuthTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\User;
+
+test('the web MCP endpoint rejects requests without a token', function () {
+    $response = $this->postJson('/mcp/biglins', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+    ], ['Accept' => 'application/json, text/event-stream']);
+
+    $response->assertUnauthorized();
+});
+
+test('the web MCP endpoint accepts a valid Sanctum token', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('agent')->plainTextToken;
+
+    $response = $this->postJson('/mcp/biglins', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+    ], [
+        'Accept' => 'application/json, text/event-stream',
+        'Authorization' => "Bearer {$token}",
+    ]);
+
+    $response->assertOk();
+});

--- a/tests/Feature/Mcp/WebTransportAuthTest.php
+++ b/tests/Feature/Mcp/WebTransportAuthTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Laravel\Passport\Passport;
 
 test('the web MCP endpoint rejects requests without a token', function () {
     $response = $this->postJson('/mcp/biglins', [
@@ -24,6 +25,18 @@ test('the web MCP endpoint accepts a valid Sanctum token', function () {
         'Accept' => 'application/json, text/event-stream',
         'Authorization' => "Bearer {$token}",
     ]);
+
+    $response->assertOk();
+});
+
+test('the web MCP endpoint accepts a valid Passport OAuth token', function () {
+    Passport::actingAs(User::factory()->create(), ['mcp:use']);
+
+    $response = $this->postJson('/mcp/biglins', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+    ], ['Accept' => 'application/json, text/event-stream']);
 
     $response->assertOk();
 });

--- a/tests/Feature/Settings/ApiTokensTest.php
+++ b/tests/Feature/Settings/ApiTokensTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Models\User;
+
+test('guests are redirected to the login page when visiting api tokens settings', function () {
+    $this->get(route('api-tokens.index'))->assertRedirect(route('login'));
+});
+
+test('api tokens settings page lists the user\'s tokens', function () {
+    $user = User::factory()->create();
+    $user->createToken('laptop');
+
+    $response = $this->actingAs($user)->get(route('api-tokens.index'));
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page->component('settings/ApiTokens')
+        ->has('tokens', 1)
+        ->where('tokens.0.name', 'laptop'));
+});
+
+test('a token can be created and the plaintext value is returned once', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post(route('api-tokens.store'), [
+        'name' => 'agent-1',
+    ]);
+
+    $response->assertSessionHasNoErrors()->assertRedirect(route('api-tokens.index'));
+    expect($user->fresh()->tokens)->toHaveCount(1);
+    expect($user->fresh()->tokens->first()->name)->toBe('agent-1');
+});
+
+test('a token name is required', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post(route('api-tokens.store'), ['name' => '']);
+
+    $response->assertSessionHasErrors('name');
+});
+
+test('a token can be revoked', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('laptop');
+
+    $response = $this->actingAs($user)->delete(route('api-tokens.destroy', $token->accessToken->id));
+
+    $response->assertRedirect(route('api-tokens.index'));
+    expect($user->fresh()->tokens)->toHaveCount(0);
+});
+
+test('a user cannot revoke another user\'s token', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $token = $otherUser->createToken('laptop');
+
+    $response = $this->actingAs($user)->delete(route('api-tokens.destroy', $token->accessToken->id));
+
+    $response->assertForbidden();
+    expect($otherUser->fresh()->tokens)->toHaveCount(1);
+});

--- a/tests/Feature/Settings/ApiTokensTest.php
+++ b/tests/Feature/Settings/ApiTokensTest.php
@@ -28,6 +28,13 @@ test('a token can be created and the plaintext value is returned once', function
     $response->assertSessionHasNoErrors()->assertRedirect(route('api-tokens.index'));
     expect($user->fresh()->tokens)->toHaveCount(1);
     expect($user->fresh()->tokens->first()->name)->toBe('agent-1');
+
+    // Inertia::flash() stores its payload in the session under
+    // `inertia.flash_data` and only removes it once an actual Inertia
+    // response is rendered (see resolveFlashData() in
+    // vendor/inertiajs/inertia-laravel/src/Response.php), so it is still
+    // readable straight off the session after the redirect response above.
+    expect(session('inertia.flash_data.newApiToken'))->toMatch('/^\d+\|.+$/');
 });
 
 test('a token name is required', function () {


### PR DESCRIPTION
## Summary

Promotes `develop` to `main`. Main addition: an [MCP](https://modelcontextprotocol.io/) server (#24) so AI agents can list/create customers, list/create estimations, list/create invoices, and send an invoice or estimation by email — 8 tools total, with two transports:

- **Local (stdio)**: for the desktop app, no auth needed (single-user, local machine).
- **HTTP** (`/mcp/biglins`): for Docker/web deployments, protected by either a Sanctum personal access token (new Settings → API Tokens page) or Passport OAuth2 (authorization code + PKCE, dynamic client registration) — added specifically so Claude Desktop's built-in connector UI, which only supports OAuth and can't take a raw bearer token, can connect.

Also includes `CurrentCompany::runningAs()` for scoping the current company outside HTTP requests (needed by the MCP tools), and a Docker entrypoint fix to generate Passport's encryption keys on container start (the container's `storage` volume is separate from the host, so a fresh deployment would otherwise boot with Passport configured but no keys).

## Test plan

- [x] Full Pest suite green (388 tests), Pint and Larastan clean
- [x] Manually verified the HTTP MCP endpoint locally: unauthenticated request returns the correct `401` + `WWW-Authenticate` OAuth challenge, `.well-known` discovery endpoints resolve, Sanctum bearer token and Passport OAuth token (via `Passport::actingAs` in tests) both authenticate successfully
- [ ] End-to-end OAuth connect from Claude Desktop's custom connector UI — blocked locally since that flow is validated by Anthropic's backend and requires a publicly reachable URL (not `localhost`); to be verified once deployed to a real domain